### PR TITLE
Add reporting charts

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -11,6 +11,8 @@ urlpatterns = [
     path("device/login/",     views.DeviceLoginView.as_view(),     name="device_login"),
     path("logout/",           LogoutView.as_view(next_page="home"), name="logout"),
     path('management/dashboard/', views.management_dashboard, name='management_dashboard'),
+    path('management/reports/', views.user_reports, name='management_reports'),
+    path('management/logs/export/', views.export_logs_csv, name='export_logs_csv'),
 
     # مرحلهٔ دوم: ثبت یا تأیید چهرهٔ مدیر برای فعال‌سازی کیوسک
     path("device/face-check/",      views.device_face_check,              name="device_face_check"),
@@ -25,6 +27,7 @@ urlpatterns = [
     # —————— کاربر عادی ——————
     path("user/inquiry/",           views.user_inquiry,                   name="user_inquiry"),
     path("user/logs/",              views.my_logs,                        name="my_logs"),
+    path("user/logs/export/",      views.export_my_logs_csv,             name="export_my_logs_csv"),
 
     # —————— پنل مدیریت ——————
     # تأیید چهرهٔ مدیر قبل از ورود به پنل

--- a/core/views.py
+++ b/core/views.py
@@ -214,6 +214,29 @@ def my_logs(request):
     return render(request, "attendance/my_logs.html", {"user": u, "logs": logs})
 
 
+@login_required
+def export_my_logs_csv(request):
+    """Export current user's logs stored in session as CSV"""
+    uid = request.session.get("inquiry_user_id")
+    if not uid:
+        return redirect("user_inquiry")
+    u = get_object_or_404(User, id=uid)
+    logs = AttendanceLog.objects.filter(user=u).order_by("-timestamp")
+    import csv
+    from django.http import HttpResponse
+    import jdatetime
+
+    response = HttpResponse(content_type='text/csv')
+    filename = f"{u.personnel_code}_logs.csv"
+    response['Content-Disposition'] = f'attachment; filename="{filename}"'
+    writer = csv.writer(response)
+    writer.writerow(['تاریخ', 'ساعت'])
+    for log in logs:
+        jd = jdatetime.datetime.fromgregorian(datetime=log.timestamp)
+        writer.writerow([jd.strftime('%Y/%m/%d'), jd.strftime('%H:%M:%S')])
+    return response
+
+
 # —————————————————————————
 # پنل مدیریت کاربران
 # —————————————————————————
@@ -367,13 +390,18 @@ def management_dashboard(request):
         logs = AttendanceLog.objects.filter(timestamp__date=date).count()
         daily_logs.append(logs)
 
+    # prepare JSON for chart rendering
+    import json
+    labels_json = json.dumps([d.strftime('%Y-%m-%d') for d in date_range])
+    logs_json = json.dumps(daily_logs)
+
     context = {
         'active_tab': 'dashboard',
         'total_users': total_users,
         'today_logs': today_logs,
         'users_without_face': users_without_face,
-        'date_range': [d.strftime("%Y-%m-%d") for d in date_range],
-        'daily_logs': daily_logs
+        'date_range_json': labels_json,
+        'daily_logs_json': logs_json,
     }
     return render(request, 'core/management_dashboard.html', context)
 
@@ -386,6 +414,12 @@ def user_reports(request):
     active_users = User.objects.filter(is_active=True).count()
     inactive_users = User.objects.filter(is_active=False).count()
     users_with_face = User.objects.filter(face_encoding__isnull=False).count()
+    total_users = User.objects.count()
+    users_without_face = total_users - users_with_face
+
+    import json
+    status_data_json = json.dumps([active_users, inactive_users])
+    face_data_json = json.dumps([users_with_face, users_without_face])
 
     # آخرین ترددها
     latest_logs = AttendanceLog.objects.select_related('user').order_by('-timestamp')[:10]
@@ -395,9 +429,36 @@ def user_reports(request):
         'active_users': active_users,
         'inactive_users': inactive_users,
         'users_with_face': users_with_face,
-        'latest_logs': latest_logs
+        'users_without_face': users_without_face,
+        'latest_logs': latest_logs,
+        'status_data_json': status_data_json,
+        'face_data_json': face_data_json,
     }
     return render(request, 'core/user_reports.html', context)
+
+
+@login_required
+@staff_required
+def export_logs_csv(request):
+    """Download all attendance logs as CSV for admins"""
+    logs = AttendanceLog.objects.select_related('user').order_by('-timestamp')
+    import csv
+    from django.http import HttpResponse
+    import jdatetime
+
+    response = HttpResponse(content_type='text/csv')
+    response['Content-Disposition'] = 'attachment; filename="attendance_logs.csv"'
+    writer = csv.writer(response)
+    writer.writerow(['کاربر', 'کد پرسنلی', 'تاریخ', 'ساعت'])
+    for log in logs:
+        jd = jdatetime.datetime.fromgregorian(datetime=log.timestamp)
+        writer.writerow([
+            log.user.get_full_name(),
+            log.user.personnel_code,
+            jd.strftime('%Y/%m/%d'),
+            jd.strftime('%H:%M:%S'),
+        ])
+    return response
 
 
 def custom_logout(request):

--- a/templates/attendance/my_logs.html
+++ b/templates/attendance/my_logs.html
@@ -32,6 +32,7 @@
     </div>
   {% endif %}
   <div style="margin-top:2rem;">
+    <a class="btn" href="{% url 'export_my_logs_csv' %}" style="margin-left:0.5rem;"><i class="fa fa-download" style="margin-left:0.4rem;"></i> دریافت CSV</a>
     <a class="btn" href="{% url 'user_inquiry' %}"><i class="fas fa-chevron-right" style="margin-left:0.4rem;"></i> بازگشت</a>
   </div>
 </div>

--- a/templates/core/base_management.html
+++ b/templates/core/base_management.html
@@ -14,6 +14,9 @@
       <a href="{% url 'management_users' %}" class="{% if request.resolver_match.url_name == 'management_users' %}active{% endif %}">
         <i class="fas fa-users"></i> کاربران
       </a>
+      <a href="{% url 'management_reports' %}" class="{% if request.resolver_match.url_name == 'management_reports' %}active{% endif %}">
+        <i class="fas fa-file-alt"></i> گزارش‌ها
+      </a>
     </nav>
   </aside>
   <section class="management-content">

--- a/templates/core/management_dashboard.html
+++ b/templates/core/management_dashboard.html
@@ -18,4 +18,28 @@
     بدون ثبت چهره
   </div>
 </div>
+<div style="margin-top:2rem;">
+  <canvas id="logsChart" height="120"></canvas>
+</div>
+{% endblock %}
+
+{% block extra_js %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+const logLabels = {{ date_range_json|safe }};
+const logData = {{ daily_logs_json|safe }};
+new Chart(document.getElementById('logsChart').getContext('2d'), {
+  type: 'line',
+  data: {
+    labels: logLabels,
+    datasets: [{
+      label: 'تعداد تردد',
+      data: logData,
+      borderColor: '#3e95cd',
+      fill: false
+    }]
+  },
+  options: {scales: {y: {beginAtZero:true}}}
+});
+</script>
 {% endblock %}

--- a/templates/core/user_reports.html
+++ b/templates/core/user_reports.html
@@ -1,0 +1,80 @@
+{% extends "core/base_management.html" %}
+{% load jformat %}
+{% block title %}گزارش کاربران{% endblock %}
+{% block management_content %}
+<h2 style="text-align:right;">
+  <i class="fas fa-file-alt" style="margin-left:0.5rem;"></i> گزارش کاربران
+</h2>
+<div class="dashboard-stats">
+  <div class="dashboard-card">
+    <h3>{{ active_users }}</h3>
+    کاربر فعال
+  </div>
+  <div class="dashboard-card">
+    <h3>{{ inactive_users }}</h3>
+    کاربر غیرفعال
+  </div>
+  <div class="dashboard-card">
+    <h3>{{ users_with_face }}</h3>
+    با ثبت چهره
+  </div>
+</div>
+<div style="margin-top:2rem;">
+  <canvas id="statusChart" height="100"></canvas>
+</div>
+<div style="margin-top:2rem;">
+  <canvas id="faceChart" height="100"></canvas>
+</div>
+<a class="btn" href="{% url 'export_logs_csv' %}" style="margin:1rem 0;display:inline-block;">
+  <i class="fa fa-download" style="margin-left:0.4rem;"></i> دانلود گزارش CSV
+</a>
+<table class="management-table">
+  <thead>
+    <tr>
+      <th>کاربر</th>
+      <th>تاریخ</th>
+      <th>ساعت</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for log in latest_logs %}
+    <tr>
+      <td>{{ log.user.get_full_name }} - {{ log.user.personnel_code }}</td>
+      <td>{{ log.timestamp|jformat:"%Y/%m/%d" }}</td>
+      <td>{{ log.timestamp|time:"H:i" }}</td>
+    </tr>
+    {% empty %}
+    <tr><td colspan="3">ترددی ثبت نشده است.</td></tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}
+
+{% block extra_js %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+const statusData = {{ status_data_json|safe }};
+new Chart(document.getElementById('statusChart').getContext('2d'), {
+  type: 'doughnut',
+  data: {
+    labels: ['فعال', 'غیرفعال'],
+    datasets: [{
+      data: statusData,
+      backgroundColor: ['#4caf50', '#f44336']
+    }]
+  }
+});
+
+const faceData = {{ face_data_json|safe }};
+new Chart(document.getElementById('faceChart').getContext('2d'), {
+  type: 'doughnut',
+  data: {
+    labels: ['با چهره', 'بدون چهره'],
+    datasets: [{
+      data: faceData,
+      backgroundColor: ['#2196f3', '#9e9e9e']
+    }]
+  }
+});
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add Chart.js visualizations to management dashboard for weekly logs
- display user status and face registration charts on reports page
- provide JSON chart data from views

## Testing
- `python manage.py check`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68728b2361b08333b5a821e34848fe42