### PR TITLE
Improve user management and profile views

### DIFF
--- a/static/core/global.css
+++ b/static/core/global.css
@@ -210,6 +210,30 @@ label {
   margin-bottom: 1.1rem;
 }
 
+/* flexible form layout */
+.form-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+.form-grid .form-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+@media (min-width: 600px) {
+  .form-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1rem 1.2rem;
+  }
+  .form-grid .full-width,
+  .form-grid .form-actions {
+    grid-column: span 2;
+  }
+}
+
 .card {
   background: linear-gradient(180deg, var(--color-surface) 0%, var(--color-bg) 100%);
   box-shadow: var(--shadow);
@@ -249,6 +273,36 @@ label {
   background: #e3f2fd44;
 }
 
+@media (max-width: 600px) {
+  .management-table,
+  .management-table thead,
+  .management-table tbody,
+  .management-table tr,
+  .management-table td {
+    display: block;
+    width: 100%;
+  }
+  .management-table thead { display: none; }
+  .management-table tr {
+    background: var(--color-bg);
+    margin-bottom: 1rem;
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+    padding: 0.6rem;
+  }
+  .management-table td {
+    border: none;
+    padding: 0.4rem 0.6rem;
+  }
+  .management-table td::before {
+    content: attr(data-label);
+    display: block;
+    font-weight: 600;
+    color: var(--color-primary-dark);
+    margin-bottom: 0.2rem;
+  }
+}
+
 /* wrapper for horizontal scroll when needed */
 .table-responsive {
   overflow-x: auto;
@@ -279,6 +333,24 @@ label {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
+}
+
+/* chart containers on report pages */
+.chart-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+  margin: 1.5rem 0;
+}
+.chart-card {
+  background: var(--color-surface);
+  padding: 1rem;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  border: 1px solid var(--color-border);
+}
+@media (min-width: 700px) {
+  .chart-grid { grid-template-columns: repeat(2, 1fr); }
 }
 
 /* general page wrapper for centering card layouts */
@@ -406,3 +478,61 @@ label {
   }
 }
 
+@media (max-width: 600px) {
+  .my-log-table,
+  .my-log-table thead,
+  .my-log-table tbody,
+  .my-log-table tr,
+  .my-log-table td { display: block; width: 100%; }
+  .my-log-table thead { display: none; }
+  .my-log-table tr {
+    background: var(--color-bg);
+    margin-bottom: 1rem;
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+    padding: 0.6rem;
+  }
+  .my-log-table td {
+    border: none;
+    padding: 0.4rem 0.6rem;
+  }
+  .my-log-table td::before {
+    content: attr(data-label);
+    display: block;
+    font-weight: 600;
+    color: var(--color-primary-dark);
+    margin-bottom: 0.2rem;
+  }
+}
+
+/* grid layout for checkbox lists */
+.checkbox-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.4rem 1rem;
+}
+@media (min-width: 500px) { .checkbox-grid { grid-template-columns: repeat(3, 1fr); } }
+@media (min-width: 800px) { .checkbox-grid { grid-template-columns: repeat(4, 1fr); } }
+
+/* collapsible sections */
+.collapsible {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  overflow: hidden;
+  margin-bottom: 1rem;
+}
+.collapsible summary {
+  padding: 0.6rem 0.8rem;
+  background: var(--color-bg);
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--color-primary-dark);
+}
+.collapsible[open] summary {
+  border-bottom: 1px solid var(--color-border);
+}
+.collapsible ul {
+  list-style: none;
+  margin: 0;
+  padding: 0.4rem 1rem 0.8rem 1rem;
+}

--- a/static/core/global.js
+++ b/static/core/global.js
@@ -36,4 +36,18 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   }
 
+  const sidebarBtn = document.getElementById("sidebar-toggle");
+  const sidebar = document.querySelector(".management-sidebar");
+  const sidebarOverlay = document.getElementById("sidebar-overlay");
+  if (sidebarBtn && sidebar && sidebarOverlay) {
+    sidebarBtn.addEventListener("click", () => {
+      sidebar.classList.toggle("open");
+      sidebarOverlay.classList.toggle("show");
+    });
+    sidebarOverlay.addEventListener("click", () => {
+      sidebar.classList.remove("open");
+      sidebarOverlay.classList.remove("show");
+    });
+  }
+
 });

--- a/static/core/management.css
+++ b/static/core/management.css
@@ -5,6 +5,29 @@
   margin: 0;
   direction: rtl;
 }
+
+.sidebar-toggle {
+  display: none;
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  background: var(--color-primary);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius);
+  padding: 0.6rem 0.8rem;
+  font-size: 1.2rem;
+  z-index: 1002;
+  box-shadow: var(--shadow);
+}
+
+.sidebar-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.4);
+  z-index: 1001;
+}
 .management-sidebar {
   width: 100%;
   background: linear-gradient(180deg, var(--color-surface) 0%, var(--color-bg) 100%);
@@ -16,6 +39,7 @@
   flex-wrap: wrap;
   justify-content: center;
   margin: 0 0 1rem 0;
+  transition: right 0.3s;
 }
 .management-sidebar .sidebar-logo {
   width: 60px;
@@ -70,12 +94,16 @@
   direction: rtl;
 }
 .dashboard-stats {
-  display: grid;
-  grid-template-columns: 1fr;
+  display: flex;
+  overflow-x: auto;
   gap: 1rem;
   margin-bottom: 2.4rem;
+  padding-bottom: 0.4rem;
+  scroll-snap-type: x mandatory;
 }
 .dashboard-card {
+  flex: 0 0 160px;
+  scroll-snap-align: start;
   background: var(--color-bg);
   border-radius: var(--radius);
   box-shadow: var(--shadow);
@@ -154,7 +182,9 @@
 }
 @media (min-width: 600px) {
   .dashboard-stats {
+    display: grid;
     grid-template-columns: repeat(2, 1fr);
+    overflow: visible;
   }
 }
 
@@ -185,5 +215,26 @@
     padding: 2.2rem 1.6rem;
     margin-bottom: 1.5rem;
   }
+  .dashboard-stats {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (max-width: 899px) {
+  .sidebar-toggle { display: block; }
+  .management-sidebar {
+    position: fixed;
+    top: 0;
+    right: -260px;
+    height: 100%;
+    width: 240px;
+    flex-direction: column;
+    overflow-y: auto;
+    padding: 2rem 1rem;
+    margin: 0;
+    z-index: 1002;
+  }
+  .management-sidebar.open { right: 0; }
+  .sidebar-overlay.show { display: block; }
 }
 

--- a/templates/attendance/my_logs.html
+++ b/templates/attendance/my_logs.html
@@ -11,16 +11,16 @@
     <a class="btn" href="?month={{ next_month }}">ماه بعد <i class="fas fa-chevron-left"></i></a>
   </div>
   <div class="table-responsive">
-    <table class="management-table">
+    <table class="management-table my-log-table">
       <thead>
         <tr><th>تاریخ</th><th>ورود</th><th>خروج</th></tr>
       </thead>
       <tbody>
         {% for day, info in daily_logs.items %}
         <tr>
-          <td>{{ jyear }}/{{ jmonth|stringformat:"02d" }}/{{ day|stringformat:"02d" }}</td>
-          <td>{% if info.in %}{{ info.in|time:"H:i" }}{% else %}-{% endif %}</td>
-          <td>{% if info.out %}{{ info.out|time:"H:i" }}{% else %}-{% endif %}</td>
+          <td data-label="تاریخ">{{ jyear }}/{{ jmonth|stringformat:"02d" }}/{{ day|stringformat:"02d" }}</td>
+          <td data-label="ورود">{% if info.in %}{{ info.in|time:"H:i" }}{% else %}-{% endif %}</td>
+          <td data-label="خروج">{% if info.out %}{{ info.out|time:"H:i" }}{% else %}-{% endif %}</td>
         </tr>
         {% endfor %}
       </tbody>

--- a/templates/core/attendance_status.html
+++ b/templates/core/attendance_status.html
@@ -2,47 +2,51 @@
 {% load jformat %}
 {% block title %}وضعیت حضور و غیاب{% endblock %}
 {% block management_content %}
-<h2 class="page-title">
-  <i class="fas fa-user-check"></i> وضعیت حضور و غیاب
-</h2>
-<form method="get" style="margin-bottom:1rem;text-align:right;">
-  {{ form.date.label_tag }}
-  {{ form.date }}
-  <button type="submit" class="btn">نمایش</button>
-</form>
-<div style="margin-bottom:1rem;text-align:right;">
-  تاریخ: {{ jdate }}
-</div>
-<div class="employee-lists">
-  <div>
-    <h4>حاضرین</h4>
-    <ul id="present-list">
-      {% for u in present_users %}
-        <li>{{ u.get_full_name }} - {{ u.personnel_code }}</li>
-      {% empty %}
-        <li>موردی نیست</li>
-      {% endfor %}
-    </ul>
-  </div>
-  <div>
-    <h4>غایبین</h4>
-    <ul id="absent-list">
-      {% for u in absent_users %}
-        <li>{{ u.get_full_name }} - {{ u.personnel_code }}</li>
-      {% empty %}
-        <li>موردی نیست</li>
-      {% endfor %}
-    </ul>
-  </div>
-  <div>
-    <h4>مرخصی</h4>
-    <ul id="leave-list">
-      {% for u in leave_users %}
-        <li>{{ u.get_full_name }} - {{ u.personnel_code }}</li>
-      {% empty %}
-        <li>موردی نیست</li>
-      {% endfor %}
-    </ul>
+<div class="card page page-md">
+  <h2 class="page-title">
+    <i class="fas fa-user-check"></i> وضعیت حضور و غیاب
+  </h2>
+  <form method="get" class="form-grid" style="margin-bottom:1rem;">
+    <div class="form-group">
+      {{ form.date.label_tag }}
+      {{ form.date }}
+    </div>
+    <div class="form-actions">
+      <button type="submit" class="btn">نمایش</button>
+    </div>
+  </form>
+  <div style="margin-bottom:1rem;text-align:right;">تاریخ: {{ jdate }}</div>
+  <div class="card-grid">
+    <details class="collapsible" open>
+      <summary>حاضرین</summary>
+      <ul id="present-list">
+        {% for u in present_users %}
+          <li>{{ u.get_full_name }} - {{ u.personnel_code }}</li>
+        {% empty %}
+          <li>موردی نیست</li>
+        {% endfor %}
+      </ul>
+    </details>
+    <details class="collapsible" open>
+      <summary>غایبین</summary>
+      <ul id="absent-list">
+        {% for u in absent_users %}
+          <li>{{ u.get_full_name }} - {{ u.personnel_code }}</li>
+        {% empty %}
+          <li>موردی نیست</li>
+        {% endfor %}
+      </ul>
+    </details>
+    <details class="collapsible" open>
+      <summary>مرخصی</summary>
+      <ul id="leave-list">
+        {% for u in leave_users %}
+          <li>{{ u.get_full_name }} - {{ u.personnel_code }}</li>
+        {% empty %}
+          <li>موردی نیست</li>
+        {% endfor %}
+</ul>
+    </details>
   </div>
 </div>
 {% endblock %}

--- a/templates/core/base_management.html
+++ b/templates/core/base_management.html
@@ -4,6 +4,10 @@
 <link rel="stylesheet" href="{% static 'core/management.css' %}">
 {% endblock %}
 {% block content %}
+<button id="sidebar-toggle" class="sidebar-toggle" aria-label="نمایش منو">
+  <i class="fas fa-bars"></i>
+</button>
+<div id="sidebar-overlay" class="sidebar-overlay"></div>
 <div class="management-layout">
   <aside class="management-sidebar">
     <div class="sidebar-title">پنل مدیریت</div>

--- a/templates/core/edit_request_form.html
+++ b/templates/core/edit_request_form.html
@@ -3,7 +3,7 @@
 {% block content %}
 <div class="card page page-md">
   <h2 class="page-title">درخواست ویرایش تردد برای {{ user.get_full_name }}</h2>
-  <form method="post">
+  <form method="post" class="form-grid">
     {% csrf_token %}
     <div class="form-group">
       {{ form.date.label_tag }}<br>
@@ -17,12 +17,14 @@
       {{ form.log_type.label_tag }}<br>
       {{ form.log_type }}
     </div>
-    <div class="form-group">
+    <div class="form-group full-width">
       {{ form.note.label_tag }}<br>
       {{ form.note }}
     </div>
-    <button type="submit" class="btn"><i class="fas fa-check" style="margin-left:0.4rem;"></i> ثبت درخواست</button>
-    <a class="btn" href="{% url 'my_logs' %}"><i class="fas fa-chevron-right" style="margin-left:0.4rem;"></i> بازگشت</a>
+    <div class="form-actions">
+      <button type="submit" class="btn"><i class="fas fa-check" style="margin-left:0.4rem;"></i> ثبت درخواست</button>
+      <a class="btn" href="{% url 'my_logs' %}"><i class="fas fa-chevron-right" style="margin-left:0.4rem;"></i> بازگشت</a>
+    </div>
   </form>
 </div>
 {% endblock %}

--- a/templates/core/edit_requests.html
+++ b/templates/core/edit_requests.html
@@ -20,14 +20,14 @@
   <tbody>
     {% for r in requests %}
     <tr>
-      <td>{{ r.user.get_full_name }} - {{ r.user.personnel_code }}</td>
-      <td>{{ r.timestamp|jformat:"%Y/%m/%d %H:%M" }}</td>
-      <td>{% if r.log_type == 'in' %}ورود{% else %}خروج{% endif %}</td>
-      <td>{{ r.note|default:"-" }}</td>
-      <td>
+      <td data-label="کاربر">{{ r.user.get_full_name }} - {{ r.user.personnel_code }}</td>
+      <td data-label="زمان">{{ r.timestamp|jformat:"%Y/%m/%d %H:%M" }}</td>
+      <td data-label="نوع">{% if r.log_type == 'in' %}ورود{% else %}خروج{% endif %}</td>
+      <td data-label="توضیح">{{ r.note|default:"-" }}</td>
+      <td data-label="وضعیت">
         {% if r.status == 'pending' %}در انتظار{% elif r.status == 'approved' %}تأیید شده{% elif r.status == 'cancelled' %}لغو شده{% else %}رد شده{% endif %}
       </td>
-      <td>
+      <td data-label="اقدام / توضیح مدیر">
         {% if r.status == 'pending' %}
         <form method="post" style="display:flex;gap:0.3rem;flex-wrap:wrap;">
           {% csrf_token %}

--- a/templates/core/leave_request_form.html
+++ b/templates/core/leave_request_form.html
@@ -3,7 +3,7 @@
 {% block content %}
 <div class="card page page-md">
   <h2 class="page-title">درخواست مرخصی برای {{ user.get_full_name }}</h2>
-  <form method="post">
+  <form method="post" class="form-grid">
     {% csrf_token %}
     <div class="form-group">
       {{ form.start_date.label_tag }}<br>
@@ -13,12 +13,14 @@
       {{ form.duration.label_tag }}<br>
       {{ form.duration }}
     </div>
-    <div class="form-group">
+    <div class="form-group full-width">
       {{ form.reason.label_tag }}<br>
       {{ form.reason }}
     </div>
-    <button type="submit" class="btn"><i class="fas fa-check" style="margin-left:0.4rem;"></i> ثبت درخواست</button>
-    <a class="btn" href="{% url 'user_profile' %}"><i class="fas fa-chevron-right" style="margin-left:0.4rem;"></i> بازگشت</a>
+    <div class="form-actions">
+      <button type="submit" class="btn"><i class="fas fa-check" style="margin-left:0.4rem;"></i> ثبت درخواست</button>
+      <a class="btn" href="{% url 'user_profile' %}"><i class="fas fa-chevron-right" style="margin-left:0.4rem;"></i> بازگشت</a>
+    </div>
   </form>
 </div>
 {% endblock %}

--- a/templates/core/leave_requests.html
+++ b/templates/core/leave_requests.html
@@ -23,14 +23,14 @@
   <tbody>
     {% for r in requests %}
     <tr>
-      <td>{{ r.user.get_full_name }} - {{ r.user.personnel_code }}</td>
-      <td>{{ r.start_date|jformat:"%Y/%m/%d" }}</td>
-      <td>{{ r.end_date|jformat:"%Y/%m/%d" }}</td>
-      <td>{{ r.reason|default:"-" }}</td>
-      <td>
+      <td data-label="کاربر">{{ r.user.get_full_name }} - {{ r.user.personnel_code }}</td>
+      <td data-label="از">{{ r.start_date|jformat:"%Y/%m/%d" }}</td>
+      <td data-label="تا">{{ r.end_date|jformat:"%Y/%m/%d" }}</td>
+      <td data-label="توضیح">{{ r.reason|default:"-" }}</td>
+      <td data-label="وضعیت">
         {% if r.status == 'pending' %}در انتظار{% elif r.status == 'approved' %}تأیید شده{% elif r.status == 'cancelled' %}لغو شده{% else %}رد شده{% endif %}
       </td>
-      <td>
+      <td data-label="اقدام / توضیح مدیر">
         {% if r.status == 'pending' %}
         <form method="post" style="display:flex;gap:0.3rem;flex-wrap:wrap;">
           {% csrf_token %}

--- a/templates/core/management_dashboard.html
+++ b/templates/core/management_dashboard.html
@@ -4,6 +4,7 @@
 <h2 class="page-title">
   <i class="fas fa-chart-bar"></i> داشبورد مدیریت
 </h2>
+
 <div class="dashboard-stats">
   <div class="dashboard-card">
     <h3>{{ total_users }}</h3>
@@ -35,27 +36,29 @@
   </div>
 </div>
 
-<h3 style="margin-top:1.5rem;">هشدارها</h3>
-<ul class="alerts-list">
-  {% for u in tardy_users %}
-    <li>{{ u.get_full_name }} - {{ u.personnel_code }} دیرکرد در ورود</li>
-  {% endfor %}
-  {% if pending_edits %}
-    <li>{{ pending_edits }} درخواست ویرایش تردد در انتظار</li>
-  {% endif %}
-  {% if pending_leaves %}
-    <li>{{ pending_leaves }} درخواست مرخصی در انتظار</li>
-  {% endif %}
-  {% if suspicious_today %}
-    <li>{{ suspicious_today }} مورد عدم تطابق چهره</li>
-  {% endif %}
-  {% if not tardy_users and not pending_edits and not pending_leaves and not suspicious_today %}
-    <li>هشداری وجود ندارد.</li>
-  {% endif %}
-</ul>
+<div class="card dashboard-alerts">
+  <h3 class="card-title">هشدارها</h3>
+  <ul class="alerts-list">
+    {% for u in tardy_users %}
+      <li>{{ u.get_full_name }} - {{ u.personnel_code }} دیرکرد در ورود</li>
+    {% endfor %}
+    {% if pending_edits %}
+      <li>{{ pending_edits }} درخواست ویرایش تردد در انتظار</li>
+    {% endif %}
+    {% if pending_leaves %}
+      <li>{{ pending_leaves }} درخواست مرخصی در انتظار</li>
+    {% endif %}
+    {% if suspicious_today %}
+      <li>{{ suspicious_today }} مورد عدم تطابق چهره</li>
+    {% endif %}
+    {% if not tardy_users and not pending_edits and not pending_leaves and not suspicious_today %}
+      <li>هشداری وجود ندارد.</li>
+    {% endif %}
+  </ul>
+</div>
 
-<div class="employee-lists">
-  <div>
+<div class="employee-lists card-grid">
+  <div class="card">
     <h4>حاضرین امروز</h4>
     <ul>
       {% for u in present_users %}
@@ -65,7 +68,7 @@
       {% endfor %}
     </ul>
   </div>
-  <div>
+  <div class="card">
     <h4>غایبین امروز</h4>
     <ul>
       {% for u in absent_users %}
@@ -75,7 +78,7 @@
       {% endfor %}
     </ul>
   </div>
-  <div>
+  <div class="card">
     <h4>در مرخصی</h4>
     <ul>
       {% for u in leave_users %}
@@ -86,7 +89,8 @@
     </ul>
   </div>
 </div>
-<div style="margin-top:2rem;">
+
+<div class="card" style="margin-top:2rem;">
   <canvas id="logsChart" height="120"></canvas>
 </div>
 {% endblock %}

--- a/templates/core/management_users.html
+++ b/templates/core/management_users.html
@@ -8,6 +8,7 @@
 <a class="btn" href="{% url 'user_add' %}" style="margin-bottom:1.4rem;">
   <i class="fas fa-user-plus" style="margin-left:0.5rem;"></i> افزودن کاربر جدید
 </a>
+<div class="table-responsive">
 <table class="management-table">
   <thead>
     <tr>
@@ -22,24 +23,24 @@
   <tbody>
     {% for user in users %}
       <tr>
-        <td>{{ forloop.counter }}</td>
-        <td>{{ user.personnel_code }}</td>
-        <td>{{ user.get_full_name }}</td>
-        <td>
+        <td data-label="ردیف">{{ forloop.counter }}</td>
+        <td data-label="کد پرسنلی">{{ user.personnel_code }}</td>
+        <td data-label="نام و نام خانوادگی">{{ user.get_full_name }}</td>
+        <td data-label="وضعیت">
           {% if user.is_active %}
             <span class="alert-success" style="padding:0.15rem 0.4rem;font-size:0.95em;">فعال</span>
           {% else %}
             <span class="alert-error" style="padding:0.15rem 0.4rem;font-size:0.95em;">غیرفعال</span>
           {% endif %}
         </td>
-        <td>
+        <td data-label="ثبت چهره">
           {% if user.face_encoding %}
             <i class="fa fa-check-circle" style="color: var(--color-secondary);"></i>
           {% else %}
             <i class="fa fa-times-circle" style="color: var(--color-error);"></i>
           {% endif %}
         </td>
-        <td>
+        <td data-label="عملیات">
           <a href="{% url 'user_update' user.pk %}" title="ویرایش"><i class="fas fa-edit"></i></a>
           <a href="{% url 'register_face_page_for_user' user.pk %}" title="ثبت چهره"><i class="fas fa-camera"></i></a>
           <a href="{% url 'user_logs_admin' user.pk %}" title="ترددها"><i class="fas fa-list"></i></a>
@@ -51,4 +52,5 @@
     {% endfor %}
   </tbody>
 </table>
+</div>
 {% endblock %}

--- a/templates/core/manual_leave_form.html
+++ b/templates/core/manual_leave_form.html
@@ -1,16 +1,17 @@
 {% extends "core/base_management.html" %}
 {% block title %}ثبت مرخصی{% endblock %}
 {% block management_content %}
-<h2 class="page-title">
-  <i class="fas fa-calendar-plus"></i>
-  ثبت مرخصی برای کاربر
-</h2>
-<a class="btn" href="{% url 'leave_requests' %}" style="margin-bottom:1rem;">
-  <i class="fas fa-chevron-right" style="margin-left:0.4rem;"></i> بازگشت
-</a>
-<form method="post" class="card" autocomplete="off">
-  {% csrf_token %}
-  {% for field in form %}
+<div class="card page page-sm">
+  <h2 class="page-title">
+    <i class="fas fa-calendar-plus"></i>
+    ثبت مرخصی برای کاربر
+  </h2>
+  <a class="btn" href="{% url 'leave_requests' %}" style="margin-bottom:1rem;">
+    <i class="fas fa-chevron-right" style="margin-left:0.4rem;"></i> بازگشت
+  </a>
+  <form method="post" class="form-grid" autocomplete="off">
+    {% csrf_token %}
+    {% for field in form %}
     <div class="form-group">
       {{ field.label_tag }}
       {{ field }}
@@ -18,9 +19,12 @@
         <div class="error">{{ error }}</div>
       {% endfor %}
     </div>
-  {% endfor %}
-  <button type="submit" class="btn"><i class="fas fa-check" style="margin-left:0.4rem;"></i> ثبت</button>
-  <a href="{% url 'leave_requests' %}" class="btn" style="background:var(--color-muted);color:#fff;">لغو</a>
-</form>
+    {% endfor %}
+    <div class="form-actions">
+      <button type="submit" class="btn"><i class="fas fa-check" style="margin-left:0.4rem;"></i> ثبت</button>
+      <a href="{% url 'leave_requests' %}" class="btn" style="background:var(--color-muted);color:#fff;">لغو</a>
+    </div>
+  </form>
+</div>
 {% endblock %}
 {% block extra_js %}{{ form.media }}{% endblock %}

--- a/templates/core/my_edit_requests.html
+++ b/templates/core/my_edit_requests.html
@@ -26,14 +26,14 @@
     <tbody>
     {% for r in requests %}
       <tr>
-        <td>{{ r.timestamp|jformat:"%Y/%m/%d %H:%M" }}</td>
-        <td>{% if r.log_type == 'in' %}ورود{% else %}خروج{% endif %}</td>
-        <td>{{ r.note|default:"-" }}</td>
-        <td>
+        <td data-label="زمان">{{ r.timestamp|jformat:"%Y/%m/%d %H:%M" }}</td>
+        <td data-label="نوع">{% if r.log_type == 'in' %}ورود{% else %}خروج{% endif %}</td>
+        <td data-label="توضیح">{{ r.note|default:"-" }}</td>
+        <td data-label="وضعیت">
           {% if r.status == 'pending' %}در انتظار{% elif r.status == 'approved' %}تأیید شده{% elif r.status == 'cancelled' %}لغو شده{% else %}رد شده{% endif %}
         </td>
-        <td>{{ r.manager_note|default:"-" }}</td>
-        <td>
+        <td data-label="توضیح مدیر">{{ r.manager_note|default:"-" }}</td>
+        <td data-label="لغو">
           {% if r.status == 'pending' %}
           <form method="post" action="{% url 'cancel_edit_request' r.id %}">
             {% csrf_token %}

--- a/templates/core/my_leave_requests.html
+++ b/templates/core/my_leave_requests.html
@@ -26,14 +26,14 @@
     <tbody>
     {% for r in requests %}
       <tr>
-        <td>{{ r.start_date|jformat:"%Y/%m/%d" }}</td>
-        <td>{{ r.end_date|jformat:"%Y/%m/%d" }}</td>
-        <td>{{ r.reason|default:"-" }}</td>
-        <td>
+        <td data-label="از">{{ r.start_date|jformat:"%Y/%m/%d" }}</td>
+        <td data-label="تا">{{ r.end_date|jformat:"%Y/%m/%d" }}</td>
+        <td data-label="توضیح">{{ r.reason|default:"-" }}</td>
+        <td data-label="وضعیت">
           {% if r.status == 'pending' %}در انتظار{% elif r.status == 'approved' %}تأیید شده{% elif r.status == 'cancelled' %}لغو شده{% else %}رد شده{% endif %}
         </td>
-        <td>{{ r.manager_note|default:"-" }}</td>
-        <td>
+        <td data-label="توضیح مدیر">{{ r.manager_note|default:"-" }}</td>
+        <td data-label="لغو">
           {% if r.status == 'pending' %}
           <form method="post" action="{% url 'cancel_leave_request' r.id %}">
             {% csrf_token %}

--- a/templates/core/suspicious_logs.html
+++ b/templates/core/suspicious_logs.html
@@ -2,30 +2,34 @@
 {% load jformat %}
 {% block title %}تشخیص‌های مشکوک{% endblock %}
 {% block management_content %}
-<h2 class="page-title">
-  <i class="fas fa-exclamation-triangle"></i>
-  تشخیص‌های مشکوک
-</h2>
-<table class="management-table">
-  <thead>
-    <tr>
-      <th>کاربر پیشنهادی</th>
-      <th>فاصله</th>
-      <th>زمان</th>
-      <th>تصویر</th>
-    </tr>
-  </thead>
-  <tbody>
-    {% for log in logs %}
-    <tr>
-      <td>{% if log.matched_user %}{{ log.matched_user.get_full_name }} - {{ log.matched_user.personnel_code }}{% else %}نامشخص{% endif %}</td>
-      <td>{{ log.similarity|floatformat:3 }}</td>
-      <td>{{ log.timestamp|jformat:"%Y/%m/%d %H:%M" }}</td>
-      <td>{% if log.image %}<img src="{{ log.image.url }}" height="40">{% else %}-{% endif %}</td>
-    </tr>
-    {% empty %}
-    <tr><td colspan="4">موردی ثبت نشده است.</td></tr>
-    {% endfor %}
-  </tbody>
-</table>
+<div class="card page page-md">
+  <h2 class="page-title">
+    <i class="fas fa-exclamation-triangle"></i>
+    تشخیص‌های مشکوک
+  </h2>
+  <div class="table-responsive">
+    <table class="management-table">
+      <thead>
+        <tr>
+          <th>کاربر پیشنهادی</th>
+          <th>فاصله</th>
+          <th>زمان</th>
+          <th>تصویر</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for log in logs %}
+        <tr>
+          <td data-label="کاربر پیشنهادی">{% if log.matched_user %}{{ log.matched_user.get_full_name }} - {{ log.matched_user.personnel_code }}{% else %}نامشخص{% endif %}</td>
+          <td data-label="فاصله">{{ log.similarity|floatformat:3 }}</td>
+          <td data-label="زمان">{{ log.timestamp|jformat:"%Y/%m/%d %H:%M" }}</td>
+          <td data-label="تصویر">{% if log.image %}<img src="{{ log.image.url }}" height="40">{% else %}-{% endif %}</td>
+        </tr>
+        {% empty %}
+        <tr><td colspan="4">موردی ثبت نشده است.</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
 {% endblock %}

--- a/templates/core/user_form.html
+++ b/templates/core/user_form.html
@@ -1,33 +1,37 @@
 {% extends "core/base_management.html" %}
 {% block title %}{% if form.instance.pk %}ویرایش کاربر{% else %}افزودن کاربر{% endif %}{% endblock %}
 {% block management_content %}
-<h2 style="text-align:right;">
-  {% if form.instance.pk %}
-    <i class="fas fa-user-edit" style="margin-left:0.5rem;"></i> ویرایش کاربر
-  {% else %}
-    <i class="fas fa-user-plus" style="margin-left:0.5rem;"></i> افزودن کاربر جدید
-  {% endif %}
-</h2>
-<a class="btn" href="{% url 'management_users' %}" style="margin-bottom:1.1rem;">
-  <i class="fas fa-chevron-right" style="margin-left:0.4rem;"></i> بازگشت به لیست
-</a>
-<form method="post" enctype="multipart/form-data" class="card" autocomplete="off">
-  {% csrf_token %}
-  {% for field in form %}
-    <div class="form-group">
-      {{ field.label_tag }}
-      {{ field }}
-      {% if field.help_text %}
-        <small style="color:var(--color-muted)">{{ field.help_text }}</small>
-      {% endif %}
-      {% for error in field.errors %}
-        <div class="error">{{ error }}</div>
-      {% endfor %}
+<div class="card page page-md">
+  <h2 class="page-title">
+    {% if form.instance.pk %}
+      <i class="fas fa-user-edit"></i> ویرایش کاربر
+    {% else %}
+      <i class="fas fa-user-plus"></i> افزودن کاربر جدید
+    {% endif %}
+  </h2>
+  <a class="btn" href="{% url 'management_users' %}" style="margin-bottom:1rem;">
+    <i class="fas fa-chevron-right" style="margin-left:0.4rem;"></i> بازگشت به لیست
+  </a>
+  <form method="post" enctype="multipart/form-data" class="form-grid" autocomplete="off">
+    {% csrf_token %}
+    {% for field in form %}
+      <div class="form-group{% if field.field.widget.input_type == 'file' %} full-width{% endif %}">
+        {{ field.label_tag }}
+        {{ field }}
+        {% if field.help_text %}
+          <small style="color:var(--color-muted)">{{ field.help_text }}</small>
+        {% endif %}
+        {% for error in field.errors %}
+          <div class="error">{{ error }}</div>
+        {% endfor %}
+      </div>
+    {% endfor %}
+    <div class="form-actions">
+      <button type="submit" class="btn">
+        {% if form.instance.pk %}ذخیره تغییرات{% else %}ایجاد کاربر{% endif %}
+      </button>
+      <a href="{% url 'management_users' %}" class="btn" style="background:var(--color-muted);color:#fff;">لغو</a>
     </div>
-  {% endfor %}
-  <button type="submit" class="btn" style="margin-left:0.7rem;">
-    {% if form.instance.pk %}ذخیره تغییرات{% else %}ایجاد کاربر{% endif %}
-  </button>
-  <a href="{% url 'management_users' %}" class="btn" style="background:var(--color-muted);color:#fff;">لغو</a>
-</form>
+  </form>
+</div>
 {% endblock %}

--- a/templates/core/user_list.html
+++ b/templates/core/user_list.html
@@ -1,13 +1,15 @@
 {% extends "core/base_management.html" %}
 {% block title %}لیست کاربران{% endblock %}
 {% block management_content %}
-<h2 style="text-align:right;">
-  <i class="fas fa-list" style="margin-left:0.5rem;"></i> لیست کاربران
-</h2>
-<a class="btn" href="{% url 'user_add' %}" style="margin-bottom:1.2rem;">
-  <i class="fas fa-user-plus" style="margin-left:0.5rem;"></i> افزودن کاربر جدید
-</a>
-<table class="management-table">
+<div class="card page page-md">
+  <h2 class="page-title">
+    <i class="fas fa-list"></i> لیست کاربران
+  </h2>
+  <a class="btn" href="{% url 'user_add' %}" style="margin-bottom:1.2rem;">
+    <i class="fas fa-user-plus" style="margin-left:0.5rem;"></i> افزودن کاربر جدید
+  </a>
+  <div class="table-responsive">
+  <table class="management-table">
   <thead>
     <tr>
       <th>ردیف</th>
@@ -44,4 +46,6 @@
     {% endfor %}
   </tbody>
 </table>
+  </div>
+</div>
 {% endblock %}

--- a/templates/core/user_logs_admin.html
+++ b/templates/core/user_logs_admin.html
@@ -2,26 +2,38 @@
 {% load jformat %}
 {% block title %}ترددهای {{ user.get_full_name }}{% endblock %}
 {% block management_content %}
-<h2 class="page-title"><i class="fas fa-list"></i> ترددهای {{ user.get_full_name }}</h2>
-<form method="get" class="form-inline" style="margin-bottom:1rem;">
-  {{ form.start.label }} {{ form.start }}
-  {{ form.end.label }} {{ form.end }}
-  <button class="btn" type="submit">نمایش</button>
-</form>
-<table class="management-table">
-  <thead>
-    <tr><th>تاریخ</th><th>ساعت</th><th>نوع</th></tr>
-  </thead>
-  <tbody>
-  {% for log in logs %}
-    <tr>
-      <td>{{ log.timestamp|jformat:"%Y/%m/%d" }}</td>
-      <td>{{ log.timestamp|time:"H:i" }}</td>
-      <td>{% if log.log_type == 'in' %}ورود{% else %}خروج{% endif %}</td>
-    </tr>
-  {% empty %}
-    <tr><td colspan="3">موردی نیست</td></tr>
-  {% endfor %}
-  </tbody>
-</table>
+<div class="card page page-md">
+  <h2 class="page-title"><i class="fas fa-list"></i> ترددهای {{ user.get_full_name }}</h2>
+  <form method="get" class="form-grid" style="margin-bottom:1rem;">
+    <div class="form-group">
+      {{ form.start.label_tag }}
+      {{ form.start }}
+    </div>
+    <div class="form-group">
+      {{ form.end.label_tag }}
+      {{ form.end }}
+    </div>
+    <div class="form-actions">
+      <button class="btn" type="submit">نمایش</button>
+    </div>
+  </form>
+  <div class="table-responsive">
+    <table class="management-table">
+      <thead>
+        <tr><th>تاریخ</th><th>ساعت</th><th>نوع</th></tr>
+      </thead>
+      <tbody>
+      {% for log in logs %}
+        <tr>
+          <td data-label="تاریخ">{{ log.timestamp|jformat:"%Y/%m/%d" }}</td>
+          <td data-label="ساعت">{{ log.timestamp|time:"H:i" }}</td>
+          <td data-label="نوع">{% if log.log_type == 'in' %}ورود{% else %}خروج{% endif %}</td>
+        </tr>
+      {% empty %}
+        <tr><td colspan="3">موردی نیست</td></tr>
+      {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
 {% endblock %}

--- a/templates/core/user_profile.html
+++ b/templates/core/user_profile.html
@@ -12,7 +12,7 @@
     <li>کد پرسنلی: {{ user.personnel_code }}</li>
     <li>کد ملی: {{ user.national_id }}</li>
   </ul>
-  <div class="profile-actions">
+  <div class="profile-actions form-actions">
     <a class="btn" href="{% url 'my_logs' %}"><i class="fa fa-list-alt" style="margin-left:0.4rem;"></i> مشاهده ترددها</a>
     <a class="btn" href="{% url 'user_leave_requests' %}"><i class="fa fa-calendar" style="margin-left:0.4rem;"></i> مرخصی‌های من</a>
     <a class="btn" href="{% url 'user_inquiry' %}"><i class="fas fa-chevron-right" style="margin-left:0.4rem;"></i> خروج</a>

--- a/templates/core/user_reports.html
+++ b/templates/core/user_reports.html
@@ -19,11 +19,13 @@
     با ثبت چهره
   </div>
 </div>
-<div style="margin-top:2rem;">
-  <canvas id="statusChart" height="100"></canvas>
-</div>
-<div style="margin-top:2rem;">
-  <canvas id="faceChart" height="100"></canvas>
+<div class="chart-grid">
+  <div class="chart-card">
+    <canvas id="statusChart" height="100"></canvas>
+  </div>
+  <div class="chart-card">
+    <canvas id="faceChart" height="100"></canvas>
+  </div>
 </div>
 <a class="btn" href="{% url 'export_logs_csv' %}" style="margin:1rem 0;display:inline-block;">
   <i class="fa fa-download" style="margin-left:0.4rem;"></i> دانلود گزارش CSV
@@ -41,11 +43,11 @@
   <tbody>
     {% for log in latest_logs %}
     <tr>
-      <td>{{ log.user.get_full_name }} - {{ log.user.personnel_code }}</td>
-      <td>{{ log.timestamp|jformat:"%Y/%m/%d" }}</td>
-      <td>{{ log.timestamp|time:"H:i" }}</td>
-      <td>{% if log.log_type == 'in' %}ورود{% else %}خروج{% endif %}</td>
-      <td>{% if log.source == 'self' %}کاربر{% elif log.source == 'auto' %}سیستم{% else %}مدیر{% endif %}</td>
+      <td data-label="کاربر">{{ log.user.get_full_name }} - {{ log.user.personnel_code }}</td>
+      <td data-label="تاریخ">{{ log.timestamp|jformat:"%Y/%m/%d" }}</td>
+      <td data-label="ساعت">{{ log.timestamp|time:"H:i" }}</td>
+      <td data-label="نوع">{% if log.log_type == 'in' %}ورود{% else %}خروج{% endif %}</td>
+      <td data-label="ثبت‌کننده">{% if log.source == 'self' %}کاربر{% elif log.source == 'auto' %}سیستم{% else %}مدیر{% endif %}</td>
     </tr>
     {% empty %}
     <tr><td colspan="5">ترددی ثبت نشده است.</td></tr>

--- a/templates/core/weekly_holidays.html
+++ b/templates/core/weekly_holidays.html
@@ -1,10 +1,17 @@
 {% extends "core/base_management.html" %}
 {% block title %}روزهای تعطیل{% endblock %}
 {% block management_content %}
-<h2 class="page-title"><i class="fas fa-calendar-day"></i> تنظیم روزهای تعطیل</h2>
-<form method="post" style="margin-top:1rem;">
-  {% csrf_token %}
-  {{ form.as_p }}
-  <button class="btn" type="submit">ذخیره</button>
-</form>
+<div class="card page page-sm">
+  <h2 class="page-title"><i class="fas fa-calendar-day"></i> تنظیم روزهای تعطیل</h2>
+  <form method="post" class="form-grid" style="margin-top:1rem;">
+    {% csrf_token %}
+    <div class="form-group full-width">
+      {{ form.days.label_tag }}
+      <div class="checkbox-grid">{{ form.days }}</div>
+    </div>
+    <div class="form-actions">
+      <button class="btn" type="submit">ذخیره</button>
+    </div>
+  </form>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- refine management pages for consistent responsive layout
- ensure suspicious log list and user logs adapt to small screens
- wrap manual leave form and user list in card containers for better mobile view

## Testing
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_b_687b8823cf788329942902bc0fc0758c