### PR TITLE
Improve profile and management views

### DIFF
--- a/static/core/global.css
+++ b/static/core/global.css
@@ -254,22 +254,81 @@ label {
   overflow-x: auto;
 }
 
+/* stacked table layout for small screens */
+.stacked-table thead {
+  display: none;
+}
+.stacked-table tr {
+  display: block;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  padding: 0.6rem 0.5rem;
+  margin-bottom: 0.8rem;
+}
+.stacked-table td {
+  display: flex;
+  justify-content: space-between;
+  padding: 0.4rem 0;
+  border-bottom: 1px solid var(--color-border);
+}
+.stacked-table td:last-child { border-bottom: none; }
+.stacked-table td::before {
+  content: attr(data-label);
+  font-weight: 600;
+  color: var(--color-primary-dark);
+  margin-left: 0.5rem;
+}
+
+@media (min-width: 600px) {
+  .stacked-table thead { display: table-header-group; }
+  .stacked-table tr {
+    display: table-row;
+    border: none;
+    box-shadow: none;
+    margin-bottom: 0;
+    padding: 0;
+  }
+  .stacked-table td {
+    display: table-cell;
+    padding: 0.9rem 0.6rem;
+  }
+  .stacked-table td::before { display: none; }
+}
+
 /* profile page tweaks */
 .profile-card {
-  text-align: right;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  animation: fadeInUp 0.5s ease both;
+}
+.profile-header {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
 }
 .profile-avatar {
-  width: 80px;
-  height: 80px;
+  width: 88px;
+  height: 88px;
   border-radius: 50%;
   object-fit: cover;
+  border: 3px solid var(--color-primary);
   box-shadow: var(--shadow);
-  margin-bottom: 1rem;
+  transition: transform 0.3s;
+}
+.profile-avatar:hover {
+  transform: scale(1.05);
 }
 .profile-details {
   list-style: none;
   padding: 0;
-  margin: 1rem 0;
+  margin: 0.5rem 0 0 0;
+  text-align: right;
 }
 .profile-details li {
   margin-bottom: 0.4rem;
@@ -279,6 +338,63 @@ label {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
+}
+@media (min-width: 600px) {
+  .profile-card {
+    flex-direction: row;
+    text-align: right;
+    align-items: flex-start;
+  }
+  .profile-header {
+    flex-direction: row;
+    align-items: center;
+    margin-bottom: 0;
+  }
+  .profile-avatar {
+    width: 110px;
+    height: 110px;
+  }
+}
+
+/* flexible form layout */
+.form-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+.form-grid .form-group {
+  flex: 1 1 180px;
+  min-width: 160px;
+}
+.form-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+/* small badge styles for table statuses */
+.badge {
+  display: inline-block;
+  padding: 0.15rem 0.45rem;
+  border-radius: 0.5rem;
+  font-size: 0.85rem;
+  color: #fff;
+}
+.badge-pending { background: var(--color-muted); }
+.badge-approved { background: var(--color-secondary); }
+.badge-rejected { background: var(--color-error); }
+.badge-cancelled { background: #777; }
+
+/* charts grid */
+.chart-grid {
+  display: grid;
+  gap: 1rem;
+}
+@media (min-width: 600px) {
+  .chart-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }
 
 /* general page wrapper for centering card layouts */

--- a/static/core/management.css
+++ b/static/core/management.css
@@ -69,20 +69,34 @@
   overflow-x: auto;
   direction: rtl;
 }
+.dashboard-section {
+  margin-bottom: 2rem;
+}
+
+.section-title {
+  font-size: 1.15rem;
+  margin: 1rem 0 0.8rem 0;
+  color: var(--color-primary-dark);
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
 .dashboard-stats {
   display: grid;
-  grid-template-columns: 1fr;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   gap: 1rem;
-  margin-bottom: 2.4rem;
+  margin-bottom: 1.5rem;
 }
 .dashboard-card {
   background: var(--color-bg);
   border-radius: var(--radius);
   box-shadow: var(--shadow);
-  padding: 1.3rem 1.1rem;
+  padding: 1.2rem 0.9rem;
   text-align: center;
   border: 1px solid var(--color-border);
-  font-size: 1.14rem;
+  font-size: 1.05rem;
+  animation: fadeInUp 0.5s ease both;
 }
 .dashboard-card h3 {
   font-size: 1.4rem;
@@ -131,6 +145,7 @@
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  animation: fadeInUp 0.5s ease both;
 }
 .alerts-list li::before {
   content: "\f0a2";
@@ -146,11 +161,47 @@
   gap: 1rem;
   margin-top: 1rem;
 }
-.employee-lists ul {
-  list-style: none;
-  padding: 0.4rem 0.6rem;
+.employee-card {
   border: 1px solid var(--color-border);
   border-radius: var(--radius);
+  padding: 0.6rem;
+  background: var(--color-bg);
+  box-shadow: var(--shadow);
+  animation: fadeInUp 0.5s ease both;
+}
+.employee-card.present { border-right: 4px solid var(--color-secondary); }
+.employee-card.absent { border-right: 4px solid var(--color-error); }
+.employee-card.leave { border-right: 4px solid var(--color-primary); }
+.employee-card h4 { margin: 0 0 0.5rem 0; }
+.employee-card li { padding: 0.25rem 0; position: relative; padding-right: 1.2rem; }
+.employee-card.present li::before,
+.employee-card.absent li::before,
+.employee-card.leave li::before {
+  font-family: 'Font Awesome 6 Free';
+  font-weight: 900;
+  position: absolute;
+  right: 0;
+  color: var(--color-muted);
+}
+.employee-card.present li::before { content: "\f058"; color: var(--color-secondary); }
+.employee-card.absent li::before { content: "\f057"; color: var(--color-error); }
+.employee-card.leave li::before { content: "\f073"; color: var(--color-primary); }
+.employee-card ul {
+  list-style: none;
+  padding: 0.3rem 0.5rem;
+}
+
+.form-inline {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.status-date {
+  margin-bottom: 1rem;
+  text-align: right;
 }
 @media (min-width: 600px) {
   .dashboard-stats {
@@ -185,5 +236,10 @@
     padding: 2.2rem 1.6rem;
     margin-bottom: 1.5rem;
   }
+}
+
+@keyframes fadeInUp {
+  from { opacity: 0; transform: translateY(12px); }
+  to { opacity: 1; transform: translateY(0); }
 }
 

--- a/templates/core/attendance_status.html
+++ b/templates/core/attendance_status.html
@@ -2,47 +2,49 @@
 {% load jformat %}
 {% block title %}وضعیت حضور و غیاب{% endblock %}
 {% block management_content %}
-<h2 class="page-title">
-  <i class="fas fa-user-check"></i> وضعیت حضور و غیاب
-</h2>
-<form method="get" style="margin-bottom:1rem;text-align:right;">
-  {{ form.date.label_tag }}
-  {{ form.date }}
-  <button type="submit" class="btn">نمایش</button>
-</form>
-<div style="margin-bottom:1rem;text-align:right;">
-  تاریخ: {{ jdate }}
-</div>
-<div class="employee-lists">
-  <div>
-    <h4>حاضرین</h4>
-    <ul id="present-list">
-      {% for u in present_users %}
-        <li>{{ u.get_full_name }} - {{ u.personnel_code }}</li>
-      {% empty %}
-        <li>موردی نیست</li>
-      {% endfor %}
-    </ul>
+<div class="card page page-md">
+  <h2 class="page-title">
+    <i class="fas fa-user-check"></i> وضعیت حضور و غیاب
+  </h2>
+  <form method="get" class="form-inline">
+    {{ form.date.label_tag }}
+    {{ form.date }}
+    <button type="submit" class="btn">نمایش</button>
+  </form>
+  <div class="status-date">
+    تاریخ: {{ jdate }}
   </div>
-  <div>
-    <h4>غایبین</h4>
-    <ul id="absent-list">
-      {% for u in absent_users %}
-        <li>{{ u.get_full_name }} - {{ u.personnel_code }}</li>
-      {% empty %}
-        <li>موردی نیست</li>
-      {% endfor %}
-    </ul>
-  </div>
-  <div>
-    <h4>مرخصی</h4>
-    <ul id="leave-list">
-      {% for u in leave_users %}
-        <li>{{ u.get_full_name }} - {{ u.personnel_code }}</li>
-      {% empty %}
-        <li>موردی نیست</li>
-      {% endfor %}
-    </ul>
+  <div class="employee-lists">
+    <div class="employee-card present">
+      <h4><i class="fa fa-user-check"></i> حاضرین</h4>
+      <ul id="present-list">
+        {% for u in present_users %}
+          <li>{{ u.get_full_name }} - {{ u.personnel_code }}</li>
+        {% empty %}
+          <li>موردی نیست</li>
+        {% endfor %}
+      </ul>
+    </div>
+    <div class="employee-card absent">
+      <h4><i class="fa fa-user-times"></i> غایبین</h4>
+      <ul id="absent-list">
+        {% for u in absent_users %}
+          <li>{{ u.get_full_name }} - {{ u.personnel_code }}</li>
+        {% empty %}
+          <li>موردی نیست</li>
+        {% endfor %}
+      </ul>
+    </div>
+    <div class="employee-card leave">
+      <h4><i class="fa fa-plane"></i> مرخصی</h4>
+      <ul id="leave-list">
+        {% for u in leave_users %}
+          <li>{{ u.get_full_name }} - {{ u.personnel_code }}</li>
+        {% empty %}
+          <li>موردی نیست</li>
+        {% endfor %}
+      </ul>
+    </div>
   </div>
 </div>
 {% endblock %}

--- a/templates/core/edit_request_form.html
+++ b/templates/core/edit_request_form.html
@@ -3,7 +3,7 @@
 {% block content %}
 <div class="card page page-md">
   <h2 class="page-title">درخواست ویرایش تردد برای {{ user.get_full_name }}</h2>
-  <form method="post">
+  <form method="post" class="form-grid">
     {% csrf_token %}
     <div class="form-group">
       {{ form.date.label_tag }}<br>
@@ -17,12 +17,14 @@
       {{ form.log_type.label_tag }}<br>
       {{ form.log_type }}
     </div>
-    <div class="form-group">
+    <div class="form-group" style="flex-basis:100%;">
       {{ form.note.label_tag }}<br>
       {{ form.note }}
     </div>
-    <button type="submit" class="btn"><i class="fas fa-check" style="margin-left:0.4rem;"></i> ثبت درخواست</button>
-    <a class="btn" href="{% url 'my_logs' %}"><i class="fas fa-chevron-right" style="margin-left:0.4rem;"></i> بازگشت</a>
+    <div class="form-actions">
+      <button type="submit" class="btn"><i class="fas fa-check" style="margin-left:0.4rem;"></i> ثبت درخواست</button>
+      <a class="btn" href="{% url 'my_logs' %}"><i class="fas fa-chevron-right" style="margin-left:0.4rem;"></i> بازگشت</a>
+    </div>
   </form>
 </div>
 {% endblock %}

--- a/templates/core/edit_requests.html
+++ b/templates/core/edit_requests.html
@@ -6,7 +6,8 @@
   <i class="fas fa-edit"></i>
   درخواست‌های ویرایش
 </h2>
-<table class="management-table">
+<div class="table-responsive">
+<table class="management-table stacked-table">
   <thead>
     <tr>
       <th>کاربر</th>
@@ -20,14 +21,22 @@
   <tbody>
     {% for r in requests %}
     <tr>
-      <td>{{ r.user.get_full_name }} - {{ r.user.personnel_code }}</td>
-      <td>{{ r.timestamp|jformat:"%Y/%m/%d %H:%M" }}</td>
-      <td>{% if r.log_type == 'in' %}ورود{% else %}خروج{% endif %}</td>
-      <td>{{ r.note|default:"-" }}</td>
-      <td>
-        {% if r.status == 'pending' %}در انتظار{% elif r.status == 'approved' %}تأیید شده{% elif r.status == 'cancelled' %}لغو شده{% else %}رد شده{% endif %}
+      <td data-label="کاربر">{{ r.user.get_full_name }} - {{ r.user.personnel_code }}</td>
+      <td data-label="زمان">{{ r.timestamp|jformat:"%Y/%m/%d %H:%M" }}</td>
+      <td data-label="نوع">{% if r.log_type == 'in' %}ورود{% else %}خروج{% endif %}</td>
+      <td data-label="توضیح">{{ r.note|default:"-" }}</td>
+      <td data-label="وضعیت">
+        {% if r.status == 'pending' %}
+          <span class="badge badge-pending">در انتظار</span>
+        {% elif r.status == 'approved' %}
+          <span class="badge badge-approved">تأیید شده</span>
+        {% elif r.status == 'cancelled' %}
+          <span class="badge badge-cancelled">لغو شده</span>
+        {% else %}
+          <span class="badge badge-rejected">رد شده</span>
+        {% endif %}
       </td>
-      <td>
+      <td data-label="اقدام / توضیح مدیر">
         {% if r.status == 'pending' %}
         <form method="post" style="display:flex;gap:0.3rem;flex-wrap:wrap;">
           {% csrf_token %}
@@ -46,5 +55,6 @@
     <tr><td colspan="6">درخواستی وجود ندارد.</td></tr>
     {% endfor %}
   </tbody>
-</table>
+  </table>
+</div>
 {% endblock %}

--- a/templates/core/leave_request_form.html
+++ b/templates/core/leave_request_form.html
@@ -3,7 +3,7 @@
 {% block content %}
 <div class="card page page-md">
   <h2 class="page-title">درخواست مرخصی برای {{ user.get_full_name }}</h2>
-  <form method="post">
+  <form method="post" class="form-grid">
     {% csrf_token %}
     <div class="form-group">
       {{ form.start_date.label_tag }}<br>
@@ -13,12 +13,14 @@
       {{ form.duration.label_tag }}<br>
       {{ form.duration }}
     </div>
-    <div class="form-group">
+    <div class="form-group" style="flex-basis:100%;">
       {{ form.reason.label_tag }}<br>
       {{ form.reason }}
     </div>
-    <button type="submit" class="btn"><i class="fas fa-check" style="margin-left:0.4rem;"></i> ثبت درخواست</button>
-    <a class="btn" href="{% url 'user_profile' %}"><i class="fas fa-chevron-right" style="margin-left:0.4rem;"></i> بازگشت</a>
+    <div class="form-actions">
+      <button type="submit" class="btn"><i class="fas fa-check" style="margin-left:0.4rem;"></i> ثبت درخواست</button>
+      <a class="btn" href="{% url 'user_profile' %}"><i class="fas fa-chevron-right" style="margin-left:0.4rem;"></i> بازگشت</a>
+    </div>
   </form>
 </div>
 {% endblock %}

--- a/templates/core/leave_requests.html
+++ b/templates/core/leave_requests.html
@@ -9,7 +9,8 @@
 <a class="btn" href="{% url 'add_leave' %}" style="margin-bottom:1rem;">
   <i class="fas fa-plus" style="margin-left:0.4rem;"></i> ثبت دستی مرخصی
 </a>
-<table class="management-table">
+<div class="table-responsive">
+<table class="management-table stacked-table">
   <thead>
     <tr>
       <th>کاربر</th>
@@ -23,14 +24,22 @@
   <tbody>
     {% for r in requests %}
     <tr>
-      <td>{{ r.user.get_full_name }} - {{ r.user.personnel_code }}</td>
-      <td>{{ r.start_date|jformat:"%Y/%m/%d" }}</td>
-      <td>{{ r.end_date|jformat:"%Y/%m/%d" }}</td>
-      <td>{{ r.reason|default:"-" }}</td>
-      <td>
-        {% if r.status == 'pending' %}در انتظار{% elif r.status == 'approved' %}تأیید شده{% elif r.status == 'cancelled' %}لغو شده{% else %}رد شده{% endif %}
+      <td data-label="کاربر">{{ r.user.get_full_name }} - {{ r.user.personnel_code }}</td>
+      <td data-label="از">{{ r.start_date|jformat:"%Y/%m/%d" }}</td>
+      <td data-label="تا">{{ r.end_date|jformat:"%Y/%m/%d" }}</td>
+      <td data-label="توضیح">{{ r.reason|default:"-" }}</td>
+      <td data-label="وضعیت">
+        {% if r.status == 'pending' %}
+          <span class="badge badge-pending">در انتظار</span>
+        {% elif r.status == 'approved' %}
+          <span class="badge badge-approved">تأیید شده</span>
+        {% elif r.status == 'cancelled' %}
+          <span class="badge badge-cancelled">لغو شده</span>
+        {% else %}
+          <span class="badge badge-rejected">رد شده</span>
+        {% endif %}
       </td>
-      <td>
+      <td data-label="اقدام / توضیح مدیر">
         {% if r.status == 'pending' %}
         <form method="post" style="display:flex;gap:0.3rem;flex-wrap:wrap;">
           {% csrf_token %}
@@ -62,5 +71,6 @@
     <tr><td colspan="6">درخواستی وجود ندارد.</td></tr>
     {% endfor %}
   </tbody>
-</table>
+  </table>
+</div>
 {% endblock %}

--- a/templates/core/management_dashboard.html
+++ b/templates/core/management_dashboard.html
@@ -4,11 +4,13 @@
 <h2 class="page-title">
   <i class="fas fa-chart-bar"></i> داشبورد مدیریت
 </h2>
-<div class="dashboard-stats">
-  <div class="dashboard-card">
-    <h3>{{ total_users }}</h3>
-    کل کاربران
-  </div>
+
+<section class="dashboard-section">
+  <div class="dashboard-stats">
+    <div class="dashboard-card">
+      <h3>{{ total_users }}</h3>
+      کل کاربران
+    </div>
   <div class="dashboard-card">
     <h3>{{ today_logs }}</h3>
     تردد امروز
@@ -34,12 +36,14 @@
     مجموع ساعات
   </div>
 </div>
+</section>
 
-<h3 style="margin-top:1.5rem;">هشدارها</h3>
-<ul class="alerts-list">
-  {% for u in tardy_users %}
-    <li>{{ u.get_full_name }} - {{ u.personnel_code }} دیرکرد در ورود</li>
-  {% endfor %}
+<section class="dashboard-section">
+  <h3 class="section-title"><i class="fas fa-bell"></i> هشدارها</h3>
+  <ul class="alerts-list">
+    {% for u in tardy_users %}
+      <li>{{ u.get_full_name }} - {{ u.personnel_code }} دیرکرد در ورود</li>
+    {% endfor %}
   {% if pending_edits %}
     <li>{{ pending_edits }} درخواست ویرایش تردد در انتظار</li>
   {% endif %}
@@ -53,42 +57,46 @@
     <li>هشداری وجود ندارد.</li>
   {% endif %}
 </ul>
+</section>
 
-<div class="employee-lists">
-  <div>
-    <h4>حاضرین امروز</h4>
-    <ul>
-      {% for u in present_users %}
-        <li>{{ u.get_full_name }} - {{ u.personnel_code }}</li>
-      {% empty %}
-        <li>موردی ثبت نشده است</li>
-      {% endfor %}
-    </ul>
+<section class="dashboard-section">
+  <div class="employee-lists">
+    <div class="employee-card">
+      <h4>حاضرین امروز</h4>
+      <ul>
+        {% for u in present_users %}
+          <li>{{ u.get_full_name }} - {{ u.personnel_code }}</li>
+        {% empty %}
+          <li>موردی ثبت نشده است</li>
+        {% endfor %}
+      </ul>
+    </div>
+    <div class="employee-card">
+      <h4>غایبین امروز</h4>
+      <ul>
+        {% for u in absent_users %}
+          <li>{{ u.get_full_name }} - {{ u.personnel_code }}</li>
+        {% empty %}
+          <li>همه حاضرند</li>
+        {% endfor %}
+      </ul>
+    </div>
+    <div class="employee-card">
+      <h4>در مرخصی</h4>
+      <ul>
+        {% for u in leave_users %}
+          <li>{{ u.get_full_name }} - {{ u.personnel_code }}</li>
+        {% empty %}
+          <li>موردی نیست</li>
+        {% endfor %}
+      </ul>
+    </div>
   </div>
-  <div>
-    <h4>غایبین امروز</h4>
-    <ul>
-      {% for u in absent_users %}
-        <li>{{ u.get_full_name }} - {{ u.personnel_code }}</li>
-      {% empty %}
-        <li>همه حاضرند</li>
-      {% endfor %}
-    </ul>
-  </div>
-  <div>
-    <h4>در مرخصی</h4>
-    <ul>
-      {% for u in leave_users %}
-        <li>{{ u.get_full_name }} - {{ u.personnel_code }}</li>
-      {% empty %}
-        <li>موردی نیست</li>
-      {% endfor %}
-    </ul>
-  </div>
-</div>
-<div style="margin-top:2rem;">
+</section>
+
+<section class="dashboard-section">
   <canvas id="logsChart" height="120"></canvas>
-</div>
+</section>
 {% endblock %}
 
 {% block extra_js %}

--- a/templates/core/management_users.html
+++ b/templates/core/management_users.html
@@ -8,7 +8,8 @@
 <a class="btn" href="{% url 'user_add' %}" style="margin-bottom:1.4rem;">
   <i class="fas fa-user-plus" style="margin-left:0.5rem;"></i> افزودن کاربر جدید
 </a>
-<table class="management-table">
+<div class="table-responsive">
+<table class="management-table stacked-table">
   <thead>
     <tr>
       <th>ردیف</th>
@@ -22,24 +23,24 @@
   <tbody>
     {% for user in users %}
       <tr>
-        <td>{{ forloop.counter }}</td>
-        <td>{{ user.personnel_code }}</td>
-        <td>{{ user.get_full_name }}</td>
-        <td>
+        <td data-label="ردیف">{{ forloop.counter }}</td>
+        <td data-label="کد پرسنلی">{{ user.personnel_code }}</td>
+        <td data-label="نام و نام خانوادگی">{{ user.get_full_name }}</td>
+        <td data-label="وضعیت">
           {% if user.is_active %}
-            <span class="alert-success" style="padding:0.15rem 0.4rem;font-size:0.95em;">فعال</span>
+            <span class="badge badge-approved">فعال</span>
           {% else %}
-            <span class="alert-error" style="padding:0.15rem 0.4rem;font-size:0.95em;">غیرفعال</span>
+            <span class="badge badge-rejected">غیرفعال</span>
           {% endif %}
         </td>
-        <td>
+        <td data-label="ثبت چهره">
           {% if user.face_encoding %}
             <i class="fa fa-check-circle" style="color: var(--color-secondary);"></i>
           {% else %}
             <i class="fa fa-times-circle" style="color: var(--color-error);"></i>
           {% endif %}
         </td>
-        <td>
+        <td data-label="عملیات">
           <a href="{% url 'user_update' user.pk %}" title="ویرایش"><i class="fas fa-edit"></i></a>
           <a href="{% url 'register_face_page_for_user' user.pk %}" title="ثبت چهره"><i class="fas fa-camera"></i></a>
           <a href="{% url 'user_logs_admin' user.pk %}" title="ترددها"><i class="fas fa-list"></i></a>
@@ -51,4 +52,5 @@
     {% endfor %}
   </tbody>
 </table>
+</div>
 {% endblock %}

--- a/templates/core/my_edit_requests.html
+++ b/templates/core/my_edit_requests.html
@@ -7,12 +7,12 @@
     <i class="fas fa-edit" style="margin-left:0.5rem;"></i>
     درخواست‌های ویرایش {{ user.get_full_name }}
   </h2>
-  <div class="profile-details" style="margin-top:0;">
+  <div class="profile-details">
     کد پرسنلی: {{ user.personnel_code }}
   </div>
   {% if requests %}
   <div class="table-responsive">
-  <table class="management-table">
+  <table class="management-table stacked-table fade-in">
     <thead>
       <tr>
         <th>زمان</th>
@@ -26,14 +26,22 @@
     <tbody>
     {% for r in requests %}
       <tr>
-        <td>{{ r.timestamp|jformat:"%Y/%m/%d %H:%M" }}</td>
-        <td>{% if r.log_type == 'in' %}ورود{% else %}خروج{% endif %}</td>
-        <td>{{ r.note|default:"-" }}</td>
-        <td>
-          {% if r.status == 'pending' %}در انتظار{% elif r.status == 'approved' %}تأیید شده{% elif r.status == 'cancelled' %}لغو شده{% else %}رد شده{% endif %}
+        <td data-label="زمان">{{ r.timestamp|jformat:"%Y/%m/%d %H:%M" }}</td>
+        <td data-label="نوع">{% if r.log_type == 'in' %}ورود{% else %}خروج{% endif %}</td>
+        <td data-label="توضیح">{{ r.note|default:"-" }}</td>
+        <td data-label="وضعیت">
+          {% if r.status == 'pending' %}
+            <span class="badge badge-pending">در انتظار</span>
+          {% elif r.status == 'approved' %}
+            <span class="badge badge-approved">تأیید شده</span>
+          {% elif r.status == 'cancelled' %}
+            <span class="badge badge-cancelled">لغو شده</span>
+          {% else %}
+            <span class="badge badge-rejected">رد شده</span>
+          {% endif %}
         </td>
-        <td>{{ r.manager_note|default:"-" }}</td>
-        <td>
+        <td data-label="توضیح مدیر">{{ r.manager_note|default:"-" }}</td>
+        <td data-label="لغو">
           {% if r.status == 'pending' %}
           <form method="post" action="{% url 'cancel_edit_request' r.id %}">
             {% csrf_token %}

--- a/templates/core/my_leave_requests.html
+++ b/templates/core/my_leave_requests.html
@@ -12,7 +12,7 @@
   </div>
   {% if requests %}
   <div class="table-responsive">
-  <table class="management-table">
+  <table class="management-table stacked-table">
     <thead>
       <tr>
         <th>از</th>
@@ -26,14 +26,22 @@
     <tbody>
     {% for r in requests %}
       <tr>
-        <td>{{ r.start_date|jformat:"%Y/%m/%d" }}</td>
-        <td>{{ r.end_date|jformat:"%Y/%m/%d" }}</td>
-        <td>{{ r.reason|default:"-" }}</td>
-        <td>
-          {% if r.status == 'pending' %}در انتظار{% elif r.status == 'approved' %}تأیید شده{% elif r.status == 'cancelled' %}لغو شده{% else %}رد شده{% endif %}
+        <td data-label="از">{{ r.start_date|jformat:"%Y/%m/%d" }}</td>
+        <td data-label="تا">{{ r.end_date|jformat:"%Y/%m/%d" }}</td>
+        <td data-label="توضیح">{{ r.reason|default:"-" }}</td>
+        <td data-label="وضعیت">
+          {% if r.status == 'pending' %}
+            <span class="badge badge-pending">در انتظار</span>
+          {% elif r.status == 'approved' %}
+            <span class="badge badge-approved">تأیید شده</span>
+          {% elif r.status == 'cancelled' %}
+            <span class="badge badge-cancelled">لغو شده</span>
+          {% else %}
+            <span class="badge badge-rejected">رد شده</span>
+          {% endif %}
         </td>
-        <td>{{ r.manager_note|default:"-" }}</td>
-        <td>
+        <td data-label="توضیح مدیر">{{ r.manager_note|default:"-" }}</td>
+        <td data-label="لغو">
           {% if r.status == 'pending' %}
           <form method="post" action="{% url 'cancel_leave_request' r.id %}">
             {% csrf_token %}

--- a/templates/core/user_form.html
+++ b/templates/core/user_form.html
@@ -1,33 +1,37 @@
 {% extends "core/base_management.html" %}
 {% block title %}{% if form.instance.pk %}ویرایش کاربر{% else %}افزودن کاربر{% endif %}{% endblock %}
 {% block management_content %}
-<h2 style="text-align:right;">
-  {% if form.instance.pk %}
-    <i class="fas fa-user-edit" style="margin-left:0.5rem;"></i> ویرایش کاربر
-  {% else %}
-    <i class="fas fa-user-plus" style="margin-left:0.5rem;"></i> افزودن کاربر جدید
-  {% endif %}
-</h2>
-<a class="btn" href="{% url 'management_users' %}" style="margin-bottom:1.1rem;">
-  <i class="fas fa-chevron-right" style="margin-left:0.4rem;"></i> بازگشت به لیست
-</a>
-<form method="post" enctype="multipart/form-data" class="card" autocomplete="off">
-  {% csrf_token %}
-  {% for field in form %}
-    <div class="form-group">
-      {{ field.label_tag }}
-      {{ field }}
-      {% if field.help_text %}
-        <small style="color:var(--color-muted)">{{ field.help_text }}</small>
-      {% endif %}
-      {% for error in field.errors %}
-        <div class="error">{{ error }}</div>
-      {% endfor %}
+<div class="card page page-md">
+  <h2 class="page-title">
+    {% if form.instance.pk %}
+      <i class="fas fa-user-edit"></i> ویرایش کاربر
+    {% else %}
+      <i class="fas fa-user-plus"></i> افزودن کاربر جدید
+    {% endif %}
+  </h2>
+  <a class="btn" href="{% url 'management_users' %}" style="margin-bottom:1.1rem;">
+    <i class="fas fa-chevron-right" style="margin-left:0.4rem;"></i> بازگشت به لیست
+  </a>
+  <form method="post" enctype="multipart/form-data" class="form-grid" autocomplete="off">
+    {% csrf_token %}
+    {% for field in form %}
+      <div class="form-group">
+        {{ field.label_tag }}
+        {{ field }}
+        {% if field.help_text %}
+          <small style="color:var(--color-muted)">{{ field.help_text }}</small>
+        {% endif %}
+        {% for error in field.errors %}
+          <div class="error">{{ error }}</div>
+        {% endfor %}
+      </div>
+    {% endfor %}
+    <div class="form-actions">
+      <button type="submit" class="btn" style="margin-left:0.7rem;">
+        {% if form.instance.pk %}ذخیره تغییرات{% else %}ایجاد کاربر{% endif %}
+      </button>
+      <a href="{% url 'management_users' %}" class="btn" style="background:var(--color-muted);color:#fff;">لغو</a>
     </div>
-  {% endfor %}
-  <button type="submit" class="btn" style="margin-left:0.7rem;">
-    {% if form.instance.pk %}ذخیره تغییرات{% else %}ایجاد کاربر{% endif %}
-  </button>
-  <a href="{% url 'management_users' %}" class="btn" style="background:var(--color-muted);color:#fff;">لغو</a>
-</form>
+  </form>
+</div>
 {% endblock %}

--- a/templates/core/user_list.html
+++ b/templates/core/user_list.html
@@ -7,7 +7,8 @@
 <a class="btn" href="{% url 'user_add' %}" style="margin-bottom:1.2rem;">
   <i class="fas fa-user-plus" style="margin-left:0.5rem;"></i> افزودن کاربر جدید
 </a>
-<table class="management-table">
+<div class="table-responsive">
+<table class="management-table stacked-table">
   <thead>
     <tr>
       <th>ردیف</th>
@@ -22,19 +23,19 @@
   <tbody>
     {% for u in users %}
       <tr>
-        <td>{{ forloop.counter }}</td>
-        <td>{{ u.personnel_code }}</td>
-        <td>{{ u.first_name }}</td>
-        <td>{{ u.last_name }}</td>
-        <td>{{ u.username }}</td>
-        <td>
+        <td data-label="ردیف">{{ forloop.counter }}</td>
+        <td data-label="کد پرسنلی">{{ u.personnel_code }}</td>
+        <td data-label="نام">{{ u.first_name }}</td>
+        <td data-label="نام خانوادگی">{{ u.last_name }}</td>
+        <td data-label="نام کاربری">{{ u.username }}</td>
+        <td data-label="ثبت چهره">
           {% if u.face_encoding %}
             <i class="fa fa-check-circle" style="color: var(--color-secondary);"></i>
           {% else %}
             <i class="fa fa-times-circle" style="color: var(--color-error);"></i>
           {% endif %}
         </td>
-        <td>
+        <td data-label="عملیات">
           <a href="{% url 'user_update' u.pk %}" title="ویرایش"><i class="fas fa-edit"></i></a>
           <a href="{% url 'user_delete' u.pk %}" title="حذف"><i class="fas fa-trash-alt"></i></a>
         </td>
@@ -44,4 +45,5 @@
     {% endfor %}
   </tbody>
 </table>
+</div>
 {% endblock %}

--- a/templates/core/user_logs_admin.html
+++ b/templates/core/user_logs_admin.html
@@ -8,20 +8,22 @@
   {{ form.end.label }} {{ form.end }}
   <button class="btn" type="submit">نمایش</button>
 </form>
-<table class="management-table">
+<div class="table-responsive">
+<table class="management-table stacked-table">
   <thead>
     <tr><th>تاریخ</th><th>ساعت</th><th>نوع</th></tr>
   </thead>
   <tbody>
   {% for log in logs %}
     <tr>
-      <td>{{ log.timestamp|jformat:"%Y/%m/%d" }}</td>
-      <td>{{ log.timestamp|time:"H:i" }}</td>
-      <td>{% if log.log_type == 'in' %}ورود{% else %}خروج{% endif %}</td>
+      <td data-label="تاریخ">{{ log.timestamp|jformat:"%Y/%m/%d" }}</td>
+      <td data-label="ساعت">{{ log.timestamp|time:"H:i" }}</td>
+      <td data-label="نوع">{% if log.log_type == 'in' %}ورود{% else %}خروج{% endif %}</td>
     </tr>
   {% empty %}
     <tr><td colspan="3">موردی نیست</td></tr>
   {% endfor %}
   </tbody>
 </table>
+</div>
 {% endblock %}

--- a/templates/core/user_profile.html
+++ b/templates/core/user_profile.html
@@ -3,15 +3,19 @@
 {% block title %}پروفایل کاربر{% endblock %}
 {% block content %}
 <div class="card page page-md profile-card">
-  <h2 class="page-title">
-    <i class="fa fa-user"></i>
-    پروفایل {{ user.get_full_name }}
-  </h2>
-  <img class="profile-avatar" src="{% if user.face_image %}{{ user.face_image.url }}{% else %}{% static 'core/avatar.png' %}{% endif %}" alt="{{ user.get_full_name }}">
-  <ul class="profile-details">
-    <li>کد پرسنلی: {{ user.personnel_code }}</li>
-    <li>کد ملی: {{ user.national_id }}</li>
-  </ul>
+  <div class="profile-header">
+    <img class="profile-avatar" src="{% if user.face_image %}{{ user.face_image.url }}{% else %}{% static 'core/avatar.png' %}{% endif %}" alt="{{ user.get_full_name }}">
+    <div>
+      <h2 class="page-title">
+        <i class="fa fa-user"></i>
+        پروفایل {{ user.get_full_name }}
+      </h2>
+      <ul class="profile-details">
+        <li><i class="fa fa-id-card" style="margin-left:0.3rem;"></i> کد پرسنلی: {{ user.personnel_code }}</li>
+        <li><i class="fa fa-fingerprint" style="margin-left:0.3rem;"></i> کد ملی: {{ user.national_id }}</li>
+      </ul>
+    </div>
+  </div>
   <div class="profile-actions">
     <a class="btn" href="{% url 'my_logs' %}"><i class="fa fa-list-alt" style="margin-left:0.4rem;"></i> مشاهده ترددها</a>
     <a class="btn" href="{% url 'user_leave_requests' %}"><i class="fa fa-calendar" style="margin-left:0.4rem;"></i> مرخصی‌های من</a>

--- a/templates/core/user_reports.html
+++ b/templates/core/user_reports.html
@@ -19,16 +19,15 @@
     با ثبت چهره
   </div>
 </div>
-<div style="margin-top:2rem;">
-  <canvas id="statusChart" height="100"></canvas>
-</div>
-<div style="margin-top:2rem;">
-  <canvas id="faceChart" height="100"></canvas>
+<div class="chart-grid" style="margin-top:2rem;">
+  <canvas id="statusChart" height="120"></canvas>
+  <canvas id="faceChart" height="120"></canvas>
 </div>
 <a class="btn" href="{% url 'export_logs_csv' %}" style="margin:1rem 0;display:inline-block;">
   <i class="fa fa-download" style="margin-left:0.4rem;"></i> دانلود گزارش CSV
 </a>
-<table class="management-table">
+<div class="table-responsive">
+<table class="management-table stacked-table">
   <thead>
     <tr>
       <th>کاربر</th>
@@ -41,17 +40,18 @@
   <tbody>
     {% for log in latest_logs %}
     <tr>
-      <td>{{ log.user.get_full_name }} - {{ log.user.personnel_code }}</td>
-      <td>{{ log.timestamp|jformat:"%Y/%m/%d" }}</td>
-      <td>{{ log.timestamp|time:"H:i" }}</td>
-      <td>{% if log.log_type == 'in' %}ورود{% else %}خروج{% endif %}</td>
-      <td>{% if log.source == 'self' %}کاربر{% elif log.source == 'auto' %}سیستم{% else %}مدیر{% endif %}</td>
+      <td data-label="کاربر">{{ log.user.get_full_name }} - {{ log.user.personnel_code }}</td>
+      <td data-label="تاریخ">{{ log.timestamp|jformat:"%Y/%m/%d" }}</td>
+      <td data-label="ساعت">{{ log.timestamp|time:"H:i" }}</td>
+      <td data-label="نوع">{% if log.log_type == 'in' %}ورود{% else %}خروج{% endif %}</td>
+      <td data-label="ثبت‌کننده">{% if log.source == 'self' %}کاربر{% elif log.source == 'auto' %}سیستم{% else %}مدیر{% endif %}</td>
     </tr>
     {% empty %}
     <tr><td colspan="5">ترددی ثبت نشده است.</td></tr>
     {% endfor %}
   </tbody>
 </table>
+</div>
 {% endblock %}
 
 {% block extra_js %}

--- a/templates/core/weekly_holidays.html
+++ b/templates/core/weekly_holidays.html
@@ -1,10 +1,14 @@
 {% extends "core/base_management.html" %}
 {% block title %}روزهای تعطیل{% endblock %}
 {% block management_content %}
-<h2 class="page-title"><i class="fas fa-calendar-day"></i> تنظیم روزهای تعطیل</h2>
-<form method="post" style="margin-top:1rem;">
-  {% csrf_token %}
-  {{ form.as_p }}
-  <button class="btn" type="submit">ذخیره</button>
-</form>
+<div class="card page page-sm">
+  <h2 class="page-title"><i class="fas fa-calendar-day"></i> تنظیم روزهای تعطیل</h2>
+  <form method="post" class="form-grid" style="margin-top:1rem;">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <div class="form-actions">
+      <button class="btn" type="submit">ذخیره</button>
+    </div>
+  </form>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- tweak profile avatar styling and details
- color attendance status cards and add icons
- use badges for request statuses across pages
- enhance employee card visuals for admin views

## Testing
- `python manage.py check`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_b_687cd2b8219c8329ab88b9a2e53c65ef