### PR TITLE
Improve responsiveness on remaining admin pages

### DIFF
--- a/static/core/global.css
+++ b/static/core/global.css
@@ -259,8 +259,8 @@ label {
   text-align: right;
 }
 .profile-avatar {
-  width: 80px;
-  height: 80px;
+  width: 100px;
+  height: 100px;
   border-radius: 50%;
   object-fit: cover;
   box-shadow: var(--shadow);
@@ -406,3 +406,31 @@ label {
   }
 }
 
+/* grid layout for forms */
+.form-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.5rem 1rem;
+}
+.form-grid .form-group { margin-bottom: 0; }
+@media (min-width: 600px) {
+  .form-grid { grid-template-columns: repeat(2, 1fr); }
+}
+
+/* card layout for personal logs */
+.log-cards { display: none; }
+.log-card {
+  background: var(--color-bg);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  border: 1px solid var(--color-border);
+  padding: 0.8rem;
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.95rem;
+}
+.log-card span:first-child { color: var(--color-muted); }
+@media (max-width: 650px) {
+  .log-cards { display: flex; flex-direction: column; gap: 0.6rem; }
+  .table-responsive, .management-table { display: none; }
+}

--- a/static/core/management.css
+++ b/static/core/management.css
@@ -71,23 +71,43 @@
 }
 .dashboard-stats {
   display: grid;
-  grid-template-columns: 1fr;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
   gap: 1rem;
   margin-bottom: 2.4rem;
+}
+@media (min-width: 1000px) {
+  .dashboard-stats {
+    grid-template-columns: repeat(3, 1fr);
+  }
 }
 .dashboard-card {
   background: var(--color-bg);
   border-radius: var(--radius);
   box-shadow: var(--shadow);
-  padding: 1.3rem 1.1rem;
+  padding: 1rem 0.8rem;
   text-align: center;
   border: 1px solid var(--color-border);
-  font-size: 1.14rem;
+  font-size: 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100px;
 }
-.dashboard-card h3 {
-  font-size: 1.4rem;
-  margin-bottom: 0.7rem;
+.dashboard-card i {
   color: var(--color-primary-dark);
+  font-size: 1.3rem;
+  margin-bottom: 0.4rem;
+}
+.dashboard-card .value {
+  font-size: 1.4rem;
+  font-weight: 700;
+  margin-bottom: 0.3rem;
+  color: var(--color-primary-dark);
+}
+.dashboard-card .label {
+  font-size: 0.9rem;
+  color: var(--color-muted);
 }
 .management-table {
   width: 100%;
@@ -146,17 +166,67 @@
   gap: 1rem;
   margin-top: 1rem;
 }
+.employee-lists > div {
+  padding: 0.4rem 0.6rem;
+}
+.employee-lists h4 {
+  margin-bottom: 0.5rem;
+  color: var(--color-primary-dark);
+  font-size: 1.05rem;
+}
 .employee-lists ul {
   list-style: none;
-  padding: 0.4rem 0.6rem;
-  border: 1px solid var(--color-border);
+  margin: 0;
+  padding: 0;
+}
+
+.panel-title {
+  margin-bottom: 1rem;
+  font-size: 1.2rem;
+  color: var(--color-primary-dark);
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+/* responsive cards used for leave/edit requests */
+.request-cards { display: none; }
+.request-card {
+  background: var(--color-bg);
   border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  border: 1px solid var(--color-border);
+  padding: 1rem 0.8rem;
 }
-@media (min-width: 600px) {
-  .dashboard-stats {
-    grid-template-columns: repeat(2, 1fr);
-  }
+.request-card .row {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.6rem;
+  margin-bottom: 0.4rem;
+  font-size: 0.95rem;
 }
+.request-card .label { color: var(--color-muted); }
+.request-card .actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-top: 0.6rem;
+}
+
+/* small-screen adjustments */
+@media (max-width: 650px) {
+  .table-responsive, .management-table { display: none; }
+  .request-cards { display: flex; flex-direction: column; gap: 1rem; }
+}
+
+/* charts container */
+.charts-grid {
+  display: flex;
+  gap: 1rem;
+  overflow-x: auto;
+  padding-bottom: 0.5rem;
+}
+.charts-grid canvas { flex: 0 0 220px; }
 
 @media (min-width: 900px) {
   .management-layout {

--- a/templates/attendance/my_logs.html
+++ b/templates/attendance/my_logs.html
@@ -10,6 +10,15 @@
     <span style="margin:0 1rem;">{{ jyear }}/{{ jmonth }}</span>
     <a class="btn" href="?month={{ next_month }}">ماه بعد <i class="fas fa-chevron-left"></i></a>
   </div>
+  <div class="log-cards">
+    {% for day, info in daily_logs.items %}
+    <div class="log-card fade-in">
+      <span>{{ jyear }}/{{ jmonth|stringformat:"02d" }}/{{ day|stringformat:"02d" }}</span>
+      <span>{% if info.in %}{{ info.in|time:"H:i" }}{% else %}-{% endif %}</span>
+      <span>{% if info.out %}{{ info.out|time:"H:i" }}{% else %}-{% endif %}</span>
+    </div>
+    {% endfor %}
+  </div>
   <div class="table-responsive">
     <table class="management-table">
       <thead>

--- a/templates/core/attendance_status.html
+++ b/templates/core/attendance_status.html
@@ -2,6 +2,7 @@
 {% load jformat %}
 {% block title %}وضعیت حضور و غیاب{% endblock %}
 {% block management_content %}
+<div class="card page page-md fade-in">
 <h2 class="page-title">
   <i class="fas fa-user-check"></i> وضعیت حضور و غیاب
 </h2>
@@ -43,7 +44,7 @@
         <li>موردی نیست</li>
       {% endfor %}
     </ul>
-  </div>
+</div>
 </div>
 {% endblock %}
 {% block extra_js %}

--- a/templates/core/edit_request_form.html
+++ b/templates/core/edit_request_form.html
@@ -21,8 +21,10 @@
       {{ form.note.label_tag }}<br>
       {{ form.note }}
     </div>
-    <button type="submit" class="btn"><i class="fas fa-check" style="margin-left:0.4rem;"></i> ثبت درخواست</button>
-    <a class="btn" href="{% url 'my_logs' %}"><i class="fas fa-chevron-right" style="margin-left:0.4rem;"></i> بازگشت</a>
+    <div class="profile-actions">
+      <button type="submit" class="btn"><i class="fas fa-check" style="margin-left:0.4rem;"></i> ثبت درخواست</button>
+      <a class="btn" href="{% url 'my_logs' %}"><i class="fas fa-chevron-right" style="margin-left:0.4rem;"></i> بازگشت</a>
+    </div>
   </form>
 </div>
 {% endblock %}

--- a/templates/core/edit_requests.html
+++ b/templates/core/edit_requests.html
@@ -6,6 +6,37 @@
   <i class="fas fa-edit"></i>
   درخواست‌های ویرایش
 </h2>
+<div class="request-cards">
+  {% for r in requests %}
+  <div class="request-card fade-in">
+    <div class="row"><span class="label">کاربر:</span><span>{{ r.user.get_full_name }} - {{ r.user.personnel_code }}</span></div>
+    <div class="row"><span class="label">زمان:</span><span>{{ r.timestamp|jformat:"%Y/%m/%d %H:%M" }}</span></div>
+    <div class="row"><span class="label">نوع:</span><span>{% if r.log_type == 'in' %}ورود{% else %}خروج{% endif %}</span></div>
+    <div class="row"><span class="label">توضیح:</span><span>{{ r.note|default:"-" }}</span></div>
+    <div class="row"><span class="label">وضعیت:</span>
+      <span>{% if r.status == 'pending' %}در انتظار{% elif r.status == 'approved' %}تأیید شده{% elif r.status == 'cancelled' %}لغو شده{% else %}رد شده{% endif %}</span>
+    </div>
+    <div class="actions">
+      {% if r.status == 'pending' %}
+      <form method="post" class="actions" style="flex:1;">
+        {% csrf_token %}
+        <input type="hidden" name="req_id" value="{{ r.id }}">
+        <input type="text" name="manager_note" placeholder="توضیح" style="flex:1;min-width:80px;">
+        <button name="action" value="approve" class="btn" style="font-size:0.9rem;">تأیید</button>
+        <button name="action" value="reject" class="btn btn-danger" style="font-size:0.9rem;">رد</button>
+        <button name="action" value="cancel" class="btn" style="font-size:0.9rem;background:var(--color-muted);">لغو</button>
+      </form>
+      {% else %}
+        {{ r.manager_note|default:"-" }}
+      {% endif %}
+    </div>
+  </div>
+  {% empty %}
+  <div class="alert-error">درخواستی وجود ندارد.</div>
+  {% endfor %}
+</div>
+
+<div class="table-responsive">
 <table class="management-table">
   <thead>
     <tr>
@@ -47,4 +78,5 @@
     {% endfor %}
   </tbody>
 </table>
+</div>
 {% endblock %}

--- a/templates/core/leave_request_form.html
+++ b/templates/core/leave_request_form.html
@@ -17,8 +17,10 @@
       {{ form.reason.label_tag }}<br>
       {{ form.reason }}
     </div>
-    <button type="submit" class="btn"><i class="fas fa-check" style="margin-left:0.4rem;"></i> ثبت درخواست</button>
-    <a class="btn" href="{% url 'user_profile' %}"><i class="fas fa-chevron-right" style="margin-left:0.4rem;"></i> بازگشت</a>
+    <div class="profile-actions">
+      <button type="submit" class="btn"><i class="fas fa-check" style="margin-left:0.4rem;"></i> ثبت درخواست</button>
+      <a class="btn" href="{% url 'user_profile' %}"><i class="fas fa-chevron-right" style="margin-left:0.4rem;"></i> بازگشت</a>
+    </div>
   </form>
 </div>
 {% endblock %}

--- a/templates/core/leave_requests.html
+++ b/templates/core/leave_requests.html
@@ -9,6 +9,52 @@
 <a class="btn" href="{% url 'add_leave' %}" style="margin-bottom:1rem;">
   <i class="fas fa-plus" style="margin-left:0.4rem;"></i> ثبت دستی مرخصی
 </a>
+<div class="request-cards">
+  {% for r in requests %}
+  <div class="request-card fade-in">
+    <div class="row"><span class="label">کاربر:</span><span>{{ r.user.get_full_name }} - {{ r.user.personnel_code }}</span></div>
+    <div class="row"><span class="label">از:</span><span>{{ r.start_date|jformat:"%Y/%m/%d" }}</span></div>
+    <div class="row"><span class="label">تا:</span><span>{{ r.end_date|jformat:"%Y/%m/%d" }}</span></div>
+    <div class="row"><span class="label">توضیح:</span><span>{{ r.reason|default:"-" }}</span></div>
+    <div class="row"><span class="label">وضعیت:</span>
+      <span>
+        {% if r.status == 'pending' %}در انتظار{% elif r.status == 'approved' %}تأیید شده{% elif r.status == 'cancelled' %}لغو شده{% else %}رد شده{% endif %}
+      </span>
+    </div>
+    <div class="actions">
+      {% if r.status == 'pending' %}
+      <form method="post" class="actions" style="flex:1;">
+        {% csrf_token %}
+        <input type="hidden" name="req_id" value="{{ r.id }}">
+        <input type="text" name="manager_note" placeholder="توضیح" style="flex:1;min-width:80px;">
+        <button name="action" value="approve" class="btn" style="font-size:0.9rem;">تأیید</button>
+        <button name="action" value="reject" class="btn btn-danger" style="font-size:0.9rem;">رد</button>
+        <button name="action" value="cancel" class="btn" style="background:var(--color-muted);font-size:0.9rem;">لغو</button>
+      </form>
+      {% elif r.start_date > today %}
+      <form method="post" class="actions" style="flex:1;">
+        {% csrf_token %}
+        <input type="hidden" name="req_id" value="{{ r.id }}">
+        <select name="status">
+          <option value="pending" {% if r.status == 'pending' %}selected{% endif %}>در انتظار</option>
+          <option value="approved" {% if r.status == 'approved' %}selected{% endif %}>تأیید شده</option>
+          <option value="rejected" {% if r.status == 'rejected' %}selected{% endif %}>رد شده</option>
+          <option value="cancelled" {% if r.status == 'cancelled' %}selected{% endif %}>لغو شده</option>
+        </select>
+        <input type="text" name="manager_note" placeholder="توضیح" style="flex:1;min-width:80px;">
+        <button name="action" value="update" class="btn" style="font-size:0.9rem;">ثبت</button>
+      </form>
+      {% else %}
+        {{ r.manager_note|default:"-" }}
+      {% endif %}
+    </div>
+  </div>
+  {% empty %}
+  <div class="alert-error">درخواستی وجود ندارد.</div>
+  {% endfor %}
+</div>
+
+<div class="table-responsive">
 <table class="management-table">
   <thead>
     <tr>
@@ -63,4 +109,5 @@
     {% endfor %}
   </tbody>
 </table>
+</div>
 {% endblock %}

--- a/templates/core/management_dashboard.html
+++ b/templates/core/management_dashboard.html
@@ -4,57 +4,70 @@
 <h2 class="page-title">
   <i class="fas fa-chart-bar"></i> داشبورد مدیریت
 </h2>
-<div class="dashboard-stats">
-  <div class="dashboard-card">
-    <h3>{{ total_users }}</h3>
-    کل کاربران
-  </div>
-  <div class="dashboard-card">
-    <h3>{{ today_logs }}</h3>
-    تردد امروز
-  </div>
-  <div class="dashboard-card">
-    <h3>{{ users_without_face }}</h3>
-    بدون ثبت چهره
-  </div>
-  <div class="dashboard-card">
-    <h3>{{ present_count }}</h3>
-    حاضر امروز
-  </div>
-  <div class="dashboard-card">
-    <h3>{{ absent_count }}</h3>
-    غایب امروز
-  </div>
-  <div class="dashboard-card">
-    <h3>{{ leave_count }}</h3>
-    در مرخصی
-  </div>
-  <div class="dashboard-card">
-    <h3>{{ total_hours }}</h3>
-    مجموع ساعات
+
+<div class="card dashboard-panel fade-in">
+  <h3 class="panel-title"><i class="fas fa-chart-pie"></i> آمار کلی</h3>
+  <div class="dashboard-stats">
+    <div class="dashboard-card">
+      <i class="fas fa-users"></i>
+      <span class="value">{{ total_users }}</span>
+      <span class="label">کل کاربران</span>
+    </div>
+    <div class="dashboard-card">
+      <i class="fas fa-clock"></i>
+      <span class="value">{{ today_logs }}</span>
+      <span class="label">تردد امروز</span>
+    </div>
+    <div class="dashboard-card">
+      <i class="fas fa-user-slash"></i>
+      <span class="value">{{ users_without_face }}</span>
+      <span class="label">بدون ثبت چهره</span>
+    </div>
+    <div class="dashboard-card">
+      <i class="fas fa-user-check"></i>
+      <span class="value">{{ present_count }}</span>
+      <span class="label">حاضر امروز</span>
+    </div>
+    <div class="dashboard-card">
+      <i class="fas fa-user-times"></i>
+      <span class="value">{{ absent_count }}</span>
+      <span class="label">غایب امروز</span>
+    </div>
+    <div class="dashboard-card">
+      <i class="fas fa-plane"></i>
+      <span class="value">{{ leave_count }}</span>
+      <span class="label">در مرخصی</span>
+    </div>
+    <div class="dashboard-card">
+      <i class="fas fa-hourglass-half"></i>
+      <span class="value">{{ total_hours }}</span>
+      <span class="label">مجموع ساعات</span>
+    </div>
   </div>
 </div>
 
-<h3 style="margin-top:1.5rem;">هشدارها</h3>
-<ul class="alerts-list">
-  {% for u in tardy_users %}
-    <li>{{ u.get_full_name }} - {{ u.personnel_code }} دیرکرد در ورود</li>
-  {% endfor %}
-  {% if pending_edits %}
-    <li>{{ pending_edits }} درخواست ویرایش تردد در انتظار</li>
-  {% endif %}
-  {% if pending_leaves %}
-    <li>{{ pending_leaves }} درخواست مرخصی در انتظار</li>
-  {% endif %}
-  {% if suspicious_today %}
-    <li>{{ suspicious_today }} مورد عدم تطابق چهره</li>
-  {% endif %}
-  {% if not tardy_users and not pending_edits and not pending_leaves and not suspicious_today %}
-    <li>هشداری وجود ندارد.</li>
-  {% endif %}
-</ul>
+<div class="card fade-in">
+  <h3 class="panel-title"><i class="fas fa-bell"></i> هشدارها</h3>
+  <ul class="alerts-list">
+    {% for u in tardy_users %}
+      <li>{{ u.get_full_name }} - {{ u.personnel_code }} دیرکرد در ورود</li>
+    {% endfor %}
+    {% if pending_edits %}
+      <li>{{ pending_edits }} درخواست ویرایش تردد در انتظار</li>
+    {% endif %}
+    {% if pending_leaves %}
+      <li>{{ pending_leaves }} درخواست مرخصی در انتظار</li>
+    {% endif %}
+    {% if suspicious_today %}
+      <li>{{ suspicious_today }} مورد عدم تطابق چهره</li>
+    {% endif %}
+    {% if not tardy_users and not pending_edits and not pending_leaves and not suspicious_today %}
+      <li>هشداری وجود ندارد.</li>
+    {% endif %}
+  </ul>
+</div>
 
-<div class="employee-lists">
+<div class="employee-lists card fade-in">
   <div>
     <h4>حاضرین امروز</h4>
     <ul>
@@ -86,7 +99,8 @@
     </ul>
   </div>
 </div>
-<div style="margin-top:2rem;">
+
+<div class="card fade-in" style="margin-top:2rem;">
   <canvas id="logsChart" height="120"></canvas>
 </div>
 {% endblock %}

--- a/templates/core/management_users.html
+++ b/templates/core/management_users.html
@@ -8,6 +8,38 @@
 <a class="btn" href="{% url 'user_add' %}" style="margin-bottom:1.4rem;">
   <i class="fas fa-user-plus" style="margin-left:0.5rem;"></i> افزودن کاربر جدید
 </a>
+<div class="request-cards">
+  {% for user in users %}
+  <div class="request-card fade-in">
+    <div class="row"><span class="label">کد پرسنلی:</span><span>{{ user.personnel_code }}</span></div>
+    <div class="row"><span class="label">نام:</span><span>{{ user.get_full_name }}</span></div>
+    <div class="row"><span class="label">وضعیت:</span>
+      {% if user.is_active %}
+        <span class="alert-success" style="padding:0 0.3rem;">فعال</span>
+      {% else %}
+        <span class="alert-error" style="padding:0 0.3rem;">غیرفعال</span>
+      {% endif %}
+    </div>
+    <div class="row"><span class="label">چهره:</span>
+      {% if user.face_encoding %}
+        <i class="fa fa-check-circle" style="color: var(--color-secondary);"></i>
+      {% else %}
+        <i class="fa fa-times-circle" style="color: var(--color-error);"></i>
+      {% endif %}
+    </div>
+    <div class="actions">
+      <a href="{% url 'user_update' user.pk %}" class="btn" style="font-size:0.9rem;">ویرایش</a>
+      <a href="{% url 'register_face_page_for_user' user.pk %}" class="btn" style="font-size:0.9rem;">چهره</a>
+      <a href="{% url 'user_logs_admin' user.pk %}" class="btn" style="font-size:0.9rem;background:var(--color-muted);">ترددها</a>
+      <a href="{% url 'user_delete' user.pk %}" class="btn btn-danger" style="font-size:0.9rem;">حذف</a>
+    </div>
+  </div>
+  {% empty %}
+  <div class="alert-error">هیچ کاربری یافت نشد</div>
+  {% endfor %}
+</div>
+
+<div class="table-responsive">
 <table class="management-table">
   <thead>
     <tr>
@@ -21,34 +53,35 @@
   </thead>
   <tbody>
     {% for user in users %}
-      <tr>
-        <td>{{ forloop.counter }}</td>
-        <td>{{ user.personnel_code }}</td>
-        <td>{{ user.get_full_name }}</td>
-        <td>
-          {% if user.is_active %}
-            <span class="alert-success" style="padding:0.15rem 0.4rem;font-size:0.95em;">فعال</span>
-          {% else %}
-            <span class="alert-error" style="padding:0.15rem 0.4rem;font-size:0.95em;">غیرفعال</span>
-          {% endif %}
-        </td>
-        <td>
-          {% if user.face_encoding %}
-            <i class="fa fa-check-circle" style="color: var(--color-secondary);"></i>
-          {% else %}
-            <i class="fa fa-times-circle" style="color: var(--color-error);"></i>
-          {% endif %}
-        </td>
-        <td>
-          <a href="{% url 'user_update' user.pk %}" title="ویرایش"><i class="fas fa-edit"></i></a>
-          <a href="{% url 'register_face_page_for_user' user.pk %}" title="ثبت چهره"><i class="fas fa-camera"></i></a>
-          <a href="{% url 'user_logs_admin' user.pk %}" title="ترددها"><i class="fas fa-list"></i></a>
-          <a href="{% url 'user_delete' user.pk %}" title="حذف"><i class="fas fa-trash-alt"></i></a>
-        </td>
-      </tr>
+    <tr>
+      <td>{{ forloop.counter }}</td>
+      <td>{{ user.personnel_code }}</td>
+      <td>{{ user.get_full_name }}</td>
+      <td>
+        {% if user.is_active %}
+          <span class="alert-success" style="padding:0.15rem 0.4rem;font-size:0.95em;">فعال</span>
+        {% else %}
+          <span class="alert-error" style="padding:0.15rem 0.4rem;font-size:0.95em;">غیرفعال</span>
+        {% endif %}
+      </td>
+      <td>
+        {% if user.face_encoding %}
+          <i class="fa fa-check-circle" style="color: var(--color-secondary);"></i>
+        {% else %}
+          <i class="fa fa-times-circle" style="color: var(--color-error);"></i>
+        {% endif %}
+      </td>
+      <td>
+        <a href="{% url 'user_update' user.pk %}" title="ویرایش"><i class="fas fa-edit"></i></a>
+        <a href="{% url 'register_face_page_for_user' user.pk %}" title="ثبت چهره"><i class="fas fa-camera"></i></a>
+        <a href="{% url 'user_logs_admin' user.pk %}" title="ترددها"><i class="fas fa-list"></i></a>
+        <a href="{% url 'user_delete' user.pk %}" title="حذف"><i class="fas fa-trash-alt"></i></a>
+      </td>
+    </tr>
     {% empty %}
-      <tr><td colspan="6">هیچ کاربری یافت نشد</td></tr>
+    <tr><td colspan="6">هیچ کاربری یافت نشد</td></tr>
     {% endfor %}
   </tbody>
 </table>
+</div>
 {% endblock %}

--- a/templates/core/manual_leave_form.html
+++ b/templates/core/manual_leave_form.html
@@ -8,7 +8,7 @@
 <a class="btn" href="{% url 'leave_requests' %}" style="margin-bottom:1rem;">
   <i class="fas fa-chevron-right" style="margin-left:0.4rem;"></i> بازگشت
 </a>
-<form method="post" class="card" autocomplete="off">
+<form method="post" class="card page page-sm form-grid" autocomplete="off">
   {% csrf_token %}
   {% for field in form %}
     <div class="form-group">
@@ -19,8 +19,10 @@
       {% endfor %}
     </div>
   {% endfor %}
-  <button type="submit" class="btn"><i class="fas fa-check" style="margin-left:0.4rem;"></i> ثبت</button>
-  <a href="{% url 'leave_requests' %}" class="btn" style="background:var(--color-muted);color:#fff;">لغو</a>
+  <div class="profile-actions" style="grid-column:1/-1;">
+    <button type="submit" class="btn"><i class="fas fa-check" style="margin-left:0.4rem;"></i> ثبت</button>
+    <a href="{% url 'leave_requests' %}" class="btn" style="background:var(--color-muted);color:#fff;">لغو</a>
+  </div>
 </form>
 {% endblock %}
 {% block extra_js %}{{ form.media }}{% endblock %}

--- a/templates/core/my_edit_requests.html
+++ b/templates/core/my_edit_requests.html
@@ -11,6 +11,28 @@
     کد پرسنلی: {{ user.personnel_code }}
   </div>
   {% if requests %}
+  <div class="request-cards">
+    {% for r in requests %}
+    <div class="request-card fade-in">
+      <div class="row"><span class="label">زمان:</span><span>{{ r.timestamp|jformat:"%Y/%m/%d %H:%M" }}</span></div>
+      <div class="row"><span class="label">نوع:</span><span>{% if r.log_type == 'in' %}ورود{% else %}خروج{% endif %}</span></div>
+      <div class="row"><span class="label">توضیح:</span><span>{{ r.note|default:"-" }}</span></div>
+      <div class="row"><span class="label">وضعیت:</span>
+        <span>{% if r.status == 'pending' %}در انتظار{% elif r.status == 'approved' %}تأیید شده{% elif r.status == 'cancelled' %}لغو شده{% else %}رد شده{% endif %}</span>
+      </div>
+      <div class="row"><span class="label">توضیح مدیر:</span><span>{{ r.manager_note|default:"-" }}</span></div>
+      <div class="actions">
+        {% if r.status == 'pending' %}
+        <form method="post" action="{% url 'cancel_edit_request' r.id %}" style="display:flex;gap:0.4rem;">
+          {% csrf_token %}
+          <button class="btn btn-danger" style="font-size:0.8rem;">لغو</button>
+        </form>
+        {% endif %}
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+
   <div class="table-responsive">
   <table class="management-table">
     <thead>

--- a/templates/core/my_leave_requests.html
+++ b/templates/core/my_leave_requests.html
@@ -11,6 +11,28 @@
     کد پرسنلی: {{ user.personnel_code }}
   </div>
   {% if requests %}
+  <div class="request-cards">
+    {% for r in requests %}
+    <div class="request-card fade-in">
+      <div class="row"><span class="label">از:</span><span>{{ r.start_date|jformat:"%Y/%m/%d" }}</span></div>
+      <div class="row"><span class="label">تا:</span><span>{{ r.end_date|jformat:"%Y/%m/%d" }}</span></div>
+      <div class="row"><span class="label">توضیح:</span><span>{{ r.reason|default:"-" }}</span></div>
+      <div class="row"><span class="label">وضعیت:</span>
+        <span>{% if r.status == 'pending' %}در انتظار{% elif r.status == 'approved' %}تأیید شده{% elif r.status == 'cancelled' %}لغو شده{% else %}رد شده{% endif %}</span>
+      </div>
+      <div class="row"><span class="label">توضیح مدیر:</span><span>{{ r.manager_note|default:"-" }}</span></div>
+      <div class="actions">
+        {% if r.status == 'pending' %}
+        <form method="post" action="{% url 'cancel_leave_request' r.id %}" style="display:flex;gap:0.4rem;">
+          {% csrf_token %}
+          <button class="btn btn-danger" style="font-size:0.8rem;">لغو</button>
+        </form>
+        {% endif %}
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+
   <div class="table-responsive">
   <table class="management-table">
     <thead>

--- a/templates/core/suspicious_logs.html
+++ b/templates/core/suspicious_logs.html
@@ -6,6 +6,19 @@
   <i class="fas fa-exclamation-triangle"></i>
   تشخیص‌های مشکوک
 </h2>
+<div class="request-cards">
+  {% for log in logs %}
+  <div class="request-card fade-in">
+    <div class="row"><span class="label">کاربر:</span><span>{% if log.matched_user %}{{ log.matched_user.get_full_name }} - {{ log.matched_user.personnel_code }}{% else %}نامشخص{% endif %}</span></div>
+    <div class="row"><span class="label">فاصله:</span><span>{{ log.similarity|floatformat:3 }}</span></div>
+    <div class="row"><span class="label">زمان:</span><span>{{ log.timestamp|jformat:"%Y/%m/%d %H:%M" }}</span></div>
+    <div class="row"><span class="label">تصویر:</span>{% if log.image %}<img src="{{ log.image.url }}" height="60">{% else %}-{% endif %}</div>
+  </div>
+  {% empty %}
+  <div class="alert-error">موردی ثبت نشده است.</div>
+  {% endfor %}
+</div>
+<div class="table-responsive">
 <table class="management-table">
   <thead>
     <tr>
@@ -28,4 +41,5 @@
     {% endfor %}
   </tbody>
 </table>
+</div>
 {% endblock %}

--- a/templates/core/user_confirm_delete.html
+++ b/templates/core/user_confirm_delete.html
@@ -4,15 +4,15 @@
 <h2 style="text-align:right;">
   <i class="fas fa-trash-alt" style="margin-left:0.5rem;"></i> حذف کاربر
 </h2>
-<div class="card">
+<div class="card page page-sm fade-in">
   <p>
     آیا مطمئن هستید که می‌خواهید کاربر
     <b>{{ user.first_name }} {{ user.last_name }}</b>
     با کد پرسنلی <b>{{ user.personnel_code }}</b> را حذف کنید؟
   </p>
-  <form method="post">
+  <form method="post" class="profile-actions">
     {% csrf_token %}
-    <button type="submit" class="btn alert-error"><i class="fas fa-trash-alt" style="margin-left:0.4rem;"></i> بله، حذف شود</button>
+    <button type="submit" class="btn btn-danger"><i class="fas fa-trash-alt" style="margin-left:0.4rem;"></i> بله، حذف شود</button>
     <a href="{% url 'management_users' %}" class="btn" style="background:var(--color-muted);color:#fff;">انصراف</a>
   </form>
 </div>

--- a/templates/core/user_form.html
+++ b/templates/core/user_form.html
@@ -11,7 +11,7 @@
 <a class="btn" href="{% url 'management_users' %}" style="margin-bottom:1.1rem;">
   <i class="fas fa-chevron-right" style="margin-left:0.4rem;"></i> بازگشت به لیست
 </a>
-<form method="post" enctype="multipart/form-data" class="card" autocomplete="off">
+<form method="post" enctype="multipart/form-data" class="card page page-sm form-grid" autocomplete="off">
   {% csrf_token %}
   {% for field in form %}
     <div class="form-group">
@@ -25,9 +25,11 @@
       {% endfor %}
     </div>
   {% endfor %}
-  <button type="submit" class="btn" style="margin-left:0.7rem;">
-    {% if form.instance.pk %}ذخیره تغییرات{% else %}ایجاد کاربر{% endif %}
-  </button>
-  <a href="{% url 'management_users' %}" class="btn" style="background:var(--color-muted);color:#fff;">لغو</a>
+  <div class="profile-actions">
+    <button type="submit" class="btn">
+      {% if form.instance.pk %}ذخیره تغییرات{% else %}ایجاد کاربر{% endif %}
+    </button>
+    <a href="{% url 'management_users' %}" class="btn" style="background:var(--color-muted);color:#fff;">لغو</a>
+  </div>
 </form>
 {% endblock %}

--- a/templates/core/user_list.html
+++ b/templates/core/user_list.html
@@ -7,6 +7,31 @@
 <a class="btn" href="{% url 'user_add' %}" style="margin-bottom:1.2rem;">
   <i class="fas fa-user-plus" style="margin-left:0.5rem;"></i> افزودن کاربر جدید
 </a>
+<div class="request-cards">
+  {% for u in users %}
+  <div class="request-card fade-in">
+    <div class="row"><span class="label">کد پرسنلی:</span><span>{{ u.personnel_code }}</span></div>
+    <div class="row"><span class="label">نام:</span><span>{{ u.get_full_name }}</span></div>
+    <div class="row"><span class="label">نام کاربری:</span><span>{{ u.username }}</span></div>
+    <div class="row"><span class="label">ثبت چهره:</span>
+      {% if u.face_encoding %}
+        <i class="fa fa-check-circle" style="color: var(--color-secondary);"></i>
+      {% else %}
+        <i class="fa fa-times-circle" style="color: var(--color-error);"></i>
+      {% endif %}
+    </div>
+    <div class="actions">
+      <a href="{% url 'user_update' u.pk %}" class="btn" style="font-size:0.9rem;">ویرایش</a>
+      <a href="{% url 'user_delete' u.pk %}" class="btn btn-danger" style="font-size:0.9rem;">حذف</a>
+      <a href="{% url 'user_logs_admin' u.pk %}" class="btn" style="font-size:0.9rem;background:var(--color-muted);">ترددها</a>
+    </div>
+  </div>
+  {% empty %}
+  <div class="alert-error">کاربری وجود ندارد</div>
+  {% endfor %}
+</div>
+
+<div class="table-responsive">
 <table class="management-table">
   <thead>
     <tr>
@@ -44,4 +69,5 @@
     {% endfor %}
   </tbody>
 </table>
+</div>
 {% endblock %}

--- a/templates/core/user_logs_admin.html
+++ b/templates/core/user_logs_admin.html
@@ -8,6 +8,18 @@
   {{ form.end.label }} {{ form.end }}
   <button class="btn" type="submit">نمایش</button>
 </form>
+<div class="log-cards">
+  {% for log in logs %}
+  <div class="log-card fade-in">
+    <span>{{ log.timestamp|jformat:"%Y/%m/%d" }}</span>
+    <span>{{ log.timestamp|time:"H:i" }}</span>
+    <span>{% if log.log_type == 'in' %}ورود{% else %}خروج{% endif %}</span>
+  </div>
+  {% empty %}
+  <div class="alert-error">موردی نیست</div>
+  {% endfor %}
+</div>
+<div class="table-responsive">
 <table class="management-table">
   <thead>
     <tr><th>تاریخ</th><th>ساعت</th><th>نوع</th></tr>
@@ -24,4 +36,5 @@
   {% endfor %}
   </tbody>
 </table>
+</div>
 {% endblock %}

--- a/templates/core/user_profile.html
+++ b/templates/core/user_profile.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% block title %}پروفایل کاربر{% endblock %}
 {% block content %}
-<div class="card page page-md profile-card">
+<div class="card page page-md profile-card fade-in">
   <h2 class="page-title">
     <i class="fa fa-user"></i>
     پروفایل {{ user.get_full_name }}

--- a/templates/core/user_reports.html
+++ b/templates/core/user_reports.html
@@ -19,15 +19,14 @@
     با ثبت چهره
   </div>
 </div>
-<div style="margin-top:2rem;">
-  <canvas id="statusChart" height="100"></canvas>
-</div>
-<div style="margin-top:2rem;">
-  <canvas id="faceChart" height="100"></canvas>
+<div class="card charts-grid fade-in" style="margin-top:1rem;">
+  <canvas id="statusChart" height="160"></canvas>
+  <canvas id="faceChart" height="160"></canvas>
 </div>
 <a class="btn" href="{% url 'export_logs_csv' %}" style="margin:1rem 0;display:inline-block;">
   <i class="fa fa-download" style="margin-left:0.4rem;"></i> دانلود گزارش CSV
 </a>
+<div class="table-responsive">
 <table class="management-table">
   <thead>
     <tr>
@@ -52,6 +51,7 @@
     {% endfor %}
   </tbody>
 </table>
+</div>
 {% endblock %}
 
 {% block extra_js %}

--- a/templates/core/weekly_holidays.html
+++ b/templates/core/weekly_holidays.html
@@ -2,9 +2,14 @@
 {% block title %}روزهای تعطیل{% endblock %}
 {% block management_content %}
 <h2 class="page-title"><i class="fas fa-calendar-day"></i> تنظیم روزهای تعطیل</h2>
-<form method="post" style="margin-top:1rem;">
+<form method="post" class="card page page-sm form-grid" style="margin-top:1rem;">
   {% csrf_token %}
-  {{ form.as_p }}
-  <button class="btn" type="submit">ذخیره</button>
+  <h3 class="panel-title" style="grid-column:1/-1;">{{ form.days.label }}</h3>
+  {% for checkbox in form.days %}
+    <label class="form-group">{{ checkbox.tag }} {{ checkbox.choice_label }}</label>
+  {% endfor %}
+  <div class="profile-actions" style="grid-column:1/-1;">
+    <button class="btn" type="submit">ذخیره</button>
+  </div>
 </form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- implement card layout for management users list
- use log cards on admin log history page
- restyle manual leave form with grid layout
- animate user deletion confirmation
- add responsive cards on suspicious logs page

## Testing
- `python manage.py check`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_b_687cd4a5176483298d838688504a50b5