### PR TITLE
Enhance user management pages responsiveness

### DIFF
--- a/static/core/global.css
+++ b/static/core/global.css
@@ -210,6 +210,25 @@ label {
   margin-bottom: 1.1rem;
 }
 
+/* flexible form grid used on management forms */
+.form-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 600px) {
+  .form-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 900px) {
+  .form-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+.form-grid .form-group { margin-bottom: 0; }
+
 .card {
   background: linear-gradient(180deg, var(--color-surface) 0%, var(--color-bg) 100%);
   box-shadow: var(--shadow);
@@ -278,7 +297,7 @@ label {
   margin-top: 1.5rem;
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: 0.8rem;
 }
 
 /* general page wrapper for centering card layouts */
@@ -289,6 +308,7 @@ label {
 }
 .page-md { max-width: 500px; }
 .page-sm { max-width: 420px; }
+.page-lg { max-width: 700px; }
 
 .page-title {
   color: var(--color-primary-dark);
@@ -298,6 +318,7 @@ label {
   align-items: center;
   gap: 0.5rem;
   justify-content: flex-start;
+  font-size: clamp(1.2rem, 4vw, 1.8rem);
 }
 
 .error, .alert-error, .alert-success {
@@ -333,6 +354,22 @@ label {
 .fade-in { animation: fadeIn 0.3s forwards; }
 .fade-out { animation: fadeOut 0.4s forwards; }
 
+/* sticky table header for long logs */
+.sticky-table thead th {
+  position: sticky;
+  top: 0;
+  background: var(--color-bg);
+  z-index: 2;
+}
+
+/* hide elements on very small screens */
+.hide-xs {
+  display: table-cell;
+}
+@media (max-width: 650px) {
+  .hide-xs { display: none; }
+}
+
 @keyframes fadeIn {
   from { opacity: 0; transform: translateY(-8px); }
   to { opacity: 1; transform: translateY(0); }
@@ -345,7 +382,7 @@ label {
 @media (min-width: 800px) {
   .header-inner,
   #main-content {
-    max-width: 950px;
+    max-width: 1200px;
     margin: 0 auto;
     padding: 1.5rem 1rem;
     border-radius: var(--radius);

--- a/static/core/management.css
+++ b/static/core/management.css
@@ -71,7 +71,7 @@
 }
 .dashboard-stats {
   display: grid;
-  grid-template-columns: 1fr;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   gap: 1rem;
   margin-bottom: 2.4rem;
 }
@@ -83,6 +83,9 @@
   text-align: center;
   border: 1px solid var(--color-border);
   font-size: 1.14rem;
+  opacity: 0;
+  transform: translateY(10px);
+  animation: fadeUp 0.6s forwards;
 }
 .dashboard-card h3 {
   font-size: 1.4rem;
@@ -117,6 +120,60 @@
   background: #e3f2fd44;
 }
 
+/* responsive table cards */
+.responsive-table {
+  width: 100%;
+}
+.responsive-table thead {
+  background: var(--color-bg);
+}
+
+@media (max-width: 650px) {
+  .responsive-table thead {
+    display: none;
+  }
+  .responsive-table,
+  .responsive-table tbody,
+  .responsive-table tr,
+  .responsive-table td {
+    display: block;
+    width: 100%;
+  }
+  .responsive-table tr {
+    margin-bottom: 1rem;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius);
+    background: var(--color-bg);
+    box-shadow: var(--shadow);
+    padding: 0.4rem;
+  }
+  .responsive-table td {
+    border: none;
+    padding: 0.5rem 0.6rem;
+    position: relative;
+  }
+  .responsive-table td + td {
+    border-top: 1px solid var(--color-border);
+  }
+  .responsive-table td[data-label]::before {
+    content: attr(data-label) ':';
+    font-weight: 600;
+    color: var(--color-primary);
+    display: block;
+    margin-bottom: 0.3rem;
+  }
+}
+
+.chart-container {
+  position: relative;
+  width: 100%;
+  margin: 1.5rem 0;
+}
+.chart-container canvas {
+  width: 100% !important;
+  height: auto !important;
+}
+
 .alerts-list {
   list-style: none;
   padding: 0;
@@ -140,11 +197,58 @@
 }
 .alerts-list li:last-child { border-bottom: none; }
 
+.alerts-collapse {
+  margin-bottom: 1.5rem;
+}
+.alerts-collapse summary {
+  cursor: pointer;
+  font-weight: 600;
+  padding: 0.4rem 0;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+.alerts-collapse summary::-webkit-details-marker { display: none; }
+.alerts-collapse[open] summary i { transform: rotate(180deg); }
+.alerts-collapse summary i { transition: transform 0.3s; }
+
+.filter-form {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 0.6rem;
+  margin-bottom: 1rem;
+}
+.filter-form button { flex-shrink: 0; }
+@media (max-width: 600px) {
+  .filter-form { flex-direction: column; align-items: stretch; }
+  .filter-form button { width: 100%; }
+}
+
 .employee-lists {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   gap: 1rem;
   margin-top: 1rem;
+}
+
+/* layout for weekly holidays checkboxes */
+.weekly-form ul {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin-bottom: 1rem;
+}
+.weekly-form li {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: 0.4rem 0.7rem;
 }
 .employee-lists ul {
   list-style: none;
@@ -155,6 +259,12 @@
 @media (min-width: 600px) {
   .dashboard-stats {
     grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 900px) {
+  .dashboard-stats {
+    grid-template-columns: repeat(3, 1fr);
   }
 }
 
@@ -185,5 +295,10 @@
     padding: 2.2rem 1.6rem;
     margin-bottom: 1.5rem;
   }
+}
+
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
 }
 

--- a/templates/attendance/my_logs.html
+++ b/templates/attendance/my_logs.html
@@ -2,7 +2,7 @@
 {% load jformat %}
 {% block title %}گزارش تردد من{% endblock %}
 {% block content %}
-<div class="card page page-md">
+<div class="card page page-md fade-in">
   <h2 class="page-title"><i class="fa fa-list-alt"></i> گزارش ترددهای {{ user.get_full_name }}</h2>
   <div class="profile-details" style="margin-top:0;">کد پرسنلی: {{ user.personnel_code }}</div>
   <div class="profile-actions" style="margin-bottom:1rem;">
@@ -11,16 +11,16 @@
     <a class="btn" href="?month={{ next_month }}">ماه بعد <i class="fas fa-chevron-left"></i></a>
   </div>
   <div class="table-responsive">
-    <table class="management-table">
+    <table class="management-table responsive-table sticky-table">
       <thead>
         <tr><th>تاریخ</th><th>ورود</th><th>خروج</th></tr>
       </thead>
       <tbody>
         {% for day, info in daily_logs.items %}
         <tr>
-          <td>{{ jyear }}/{{ jmonth|stringformat:"02d" }}/{{ day|stringformat:"02d" }}</td>
-          <td>{% if info.in %}{{ info.in|time:"H:i" }}{% else %}-{% endif %}</td>
-          <td>{% if info.out %}{{ info.out|time:"H:i" }}{% else %}-{% endif %}</td>
+          <td data-label="تاریخ">{{ jyear }}/{{ jmonth|stringformat:"02d" }}/{{ day|stringformat:"02d" }}</td>
+          <td data-label="ورود">{% if info.in %}{{ info.in|time:"H:i" }}{% else %}-{% endif %}</td>
+          <td data-label="خروج">{% if info.out %}{{ info.out|time:"H:i" }}{% else %}-{% endif %}</td>
         </tr>
         {% endfor %}
       </tbody>

--- a/templates/core/attendance_status.html
+++ b/templates/core/attendance_status.html
@@ -5,15 +5,16 @@
 <h2 class="page-title">
   <i class="fas fa-user-check"></i> وضعیت حضور و غیاب
 </h2>
-<form method="get" style="margin-bottom:1rem;text-align:right;">
-  {{ form.date.label_tag }}
-  {{ form.date }}
-  <button type="submit" class="btn">نمایش</button>
-</form>
-<div style="margin-bottom:1rem;text-align:right;">
-  تاریخ: {{ jdate }}
-</div>
-<div class="employee-lists">
+<div class="card fade-in">
+  <form method="get" class="filter-form">
+    {{ form.date.label_tag }}
+    {{ form.date }}
+    <button type="submit" class="btn">نمایش</button>
+  </form>
+  <div style="margin-bottom:1rem;text-align:right;">
+    تاریخ: {{ jdate }}
+  </div>
+  <div class="employee-lists">
   <div>
     <h4>حاضرین</h4>
     <ul id="present-list">
@@ -43,6 +44,7 @@
         <li>موردی نیست</li>
       {% endfor %}
     </ul>
+  </div>
   </div>
 </div>
 {% endblock %}

--- a/templates/core/edit_request_form.html
+++ b/templates/core/edit_request_form.html
@@ -1,7 +1,7 @@
 {% extends "core/base.html" %}
 {% block title %}درخواست ویرایش تردد{% endblock %}
 {% block content %}
-<div class="card page page-md">
+<div class="card page page-md fade-in">
   <h2 class="page-title">درخواست ویرایش تردد برای {{ user.get_full_name }}</h2>
   <form method="post">
     {% csrf_token %}

--- a/templates/core/edit_requests.html
+++ b/templates/core/edit_requests.html
@@ -6,7 +6,8 @@
   <i class="fas fa-edit"></i>
   درخواست‌های ویرایش
 </h2>
-<table class="management-table">
+<div class="table-responsive">
+<table class="management-table responsive-table fade-in">
   <thead>
     <tr>
       <th>کاربر</th>
@@ -20,14 +21,14 @@
   <tbody>
     {% for r in requests %}
     <tr>
-      <td>{{ r.user.get_full_name }} - {{ r.user.personnel_code }}</td>
-      <td>{{ r.timestamp|jformat:"%Y/%m/%d %H:%M" }}</td>
-      <td>{% if r.log_type == 'in' %}ورود{% else %}خروج{% endif %}</td>
-      <td>{{ r.note|default:"-" }}</td>
-      <td>
+      <td data-label="کاربر">{{ r.user.get_full_name }} - {{ r.user.personnel_code }}</td>
+      <td data-label="زمان">{{ r.timestamp|jformat:"%Y/%m/%d %H:%M" }}</td>
+      <td data-label="نوع">{% if r.log_type == 'in' %}ورود{% else %}خروج{% endif %}</td>
+      <td data-label="توضیح">{{ r.note|default:"-" }}</td>
+      <td data-label="وضعیت">
         {% if r.status == 'pending' %}در انتظار{% elif r.status == 'approved' %}تأیید شده{% elif r.status == 'cancelled' %}لغو شده{% else %}رد شده{% endif %}
       </td>
-      <td>
+      <td data-label="اقدام یا توضیح">
         {% if r.status == 'pending' %}
         <form method="post" style="display:flex;gap:0.3rem;flex-wrap:wrap;">
           {% csrf_token %}
@@ -47,4 +48,5 @@
     {% endfor %}
   </tbody>
 </table>
+</div>
 {% endblock %}

--- a/templates/core/leave_request_form.html
+++ b/templates/core/leave_request_form.html
@@ -1,7 +1,7 @@
 {% extends "core/base.html" %}
 {% block title %}درخواست مرخصی{% endblock %}
 {% block content %}
-<div class="card page page-md">
+<div class="card page page-md fade-in">
   <h2 class="page-title">درخواست مرخصی برای {{ user.get_full_name }}</h2>
   <form method="post">
     {% csrf_token %}

--- a/templates/core/leave_requests.html
+++ b/templates/core/leave_requests.html
@@ -9,7 +9,8 @@
 <a class="btn" href="{% url 'add_leave' %}" style="margin-bottom:1rem;">
   <i class="fas fa-plus" style="margin-left:0.4rem;"></i> ثبت دستی مرخصی
 </a>
-<table class="management-table">
+<div class="table-responsive">
+<table class="management-table responsive-table fade-in">
   <thead>
     <tr>
       <th>کاربر</th>
@@ -23,14 +24,14 @@
   <tbody>
     {% for r in requests %}
     <tr>
-      <td>{{ r.user.get_full_name }} - {{ r.user.personnel_code }}</td>
-      <td>{{ r.start_date|jformat:"%Y/%m/%d" }}</td>
-      <td>{{ r.end_date|jformat:"%Y/%m/%d" }}</td>
-      <td>{{ r.reason|default:"-" }}</td>
-      <td>
+      <td data-label="کاربر">{{ r.user.get_full_name }} - {{ r.user.personnel_code }}</td>
+      <td data-label="از">{{ r.start_date|jformat:"%Y/%m/%d" }}</td>
+      <td data-label="تا">{{ r.end_date|jformat:"%Y/%m/%d" }}</td>
+      <td data-label="توضیح">{{ r.reason|default:"-" }}</td>
+      <td data-label="وضعیت">
         {% if r.status == 'pending' %}در انتظار{% elif r.status == 'approved' %}تأیید شده{% elif r.status == 'cancelled' %}لغو شده{% else %}رد شده{% endif %}
       </td>
-      <td>
+      <td data-label="اقدام یا توضیح">
         {% if r.status == 'pending' %}
         <form method="post" style="display:flex;gap:0.3rem;flex-wrap:wrap;">
           {% csrf_token %}
@@ -63,4 +64,5 @@
     {% endfor %}
   </tbody>
 </table>
+</div>
 {% endblock %}

--- a/templates/core/management_dashboard.html
+++ b/templates/core/management_dashboard.html
@@ -1,7 +1,7 @@
 {% extends "core/base_management.html" %}
 {% block title %}داشبورد مدیریت{% endblock %}
 {% block management_content %}
-<h2 class="page-title">
+<h2 class="page-title dashboard-title">
   <i class="fas fa-chart-bar"></i> داشبورد مدیریت
 </h2>
 <div class="dashboard-stats">
@@ -34,25 +34,26 @@
     مجموع ساعات
   </div>
 </div>
-
-<h3 style="margin-top:1.5rem;">هشدارها</h3>
-<ul class="alerts-list">
-  {% for u in tardy_users %}
-    <li>{{ u.get_full_name }} - {{ u.personnel_code }} دیرکرد در ورود</li>
-  {% endfor %}
-  {% if pending_edits %}
-    <li>{{ pending_edits }} درخواست ویرایش تردد در انتظار</li>
-  {% endif %}
-  {% if pending_leaves %}
-    <li>{{ pending_leaves }} درخواست مرخصی در انتظار</li>
-  {% endif %}
-  {% if suspicious_today %}
-    <li>{{ suspicious_today }} مورد عدم تطابق چهره</li>
-  {% endif %}
-  {% if not tardy_users and not pending_edits and not pending_leaves and not suspicious_today %}
-    <li>هشداری وجود ندارد.</li>
-  {% endif %}
-</ul>
+<details class="alerts-collapse"{% if not tardy_users and not pending_edits and not pending_leaves and not suspicious_today %} open{% endif %}>
+  <summary><i class="fas fa-bell"></i> هشدارها</summary>
+  <ul class="alerts-list">
+    {% for u in tardy_users %}
+      <li>{{ u.get_full_name }} - {{ u.personnel_code }} دیرکرد در ورود</li>
+    {% endfor %}
+    {% if pending_edits %}
+      <li>{{ pending_edits }} درخواست ویرایش تردد در انتظار</li>
+    {% endif %}
+    {% if pending_leaves %}
+      <li>{{ pending_leaves }} درخواست مرخصی در انتظار</li>
+    {% endif %}
+    {% if suspicious_today %}
+      <li>{{ suspicious_today }} مورد عدم تطابق چهره</li>
+    {% endif %}
+    {% if not tardy_users and not pending_edits and not pending_leaves and not suspicious_today %}
+      <li>هشداری وجود ندارد.</li>
+    {% endif %}
+  </ul>
+</details>
 
 <div class="employee-lists">
   <div>

--- a/templates/core/management_users.html
+++ b/templates/core/management_users.html
@@ -8,10 +8,11 @@
 <a class="btn" href="{% url 'user_add' %}" style="margin-bottom:1.4rem;">
   <i class="fas fa-user-plus" style="margin-left:0.5rem;"></i> افزودن کاربر جدید
 </a>
-<table class="management-table">
+<div class="table-responsive">
+<table class="management-table responsive-table fade-in">
   <thead>
     <tr>
-      <th>ردیف</th>
+      <th class="hide-xs">ردیف</th>
       <th>کد پرسنلی</th>
       <th>نام و نام خانوادگی</th>
       <th>وضعیت</th>
@@ -22,24 +23,24 @@
   <tbody>
     {% for user in users %}
       <tr>
-        <td>{{ forloop.counter }}</td>
-        <td>{{ user.personnel_code }}</td>
-        <td>{{ user.get_full_name }}</td>
-        <td>
+        <td data-label="ردیف" class="hide-xs">{{ forloop.counter }}</td>
+        <td data-label="کد پرسنلی">{{ user.personnel_code }}</td>
+        <td data-label="نام">{{ user.get_full_name }}</td>
+        <td data-label="وضعیت">
           {% if user.is_active %}
             <span class="alert-success" style="padding:0.15rem 0.4rem;font-size:0.95em;">فعال</span>
           {% else %}
             <span class="alert-error" style="padding:0.15rem 0.4rem;font-size:0.95em;">غیرفعال</span>
           {% endif %}
         </td>
-        <td>
+        <td data-label="ثبت چهره">
           {% if user.face_encoding %}
             <i class="fa fa-check-circle" style="color: var(--color-secondary);"></i>
           {% else %}
             <i class="fa fa-times-circle" style="color: var(--color-error);"></i>
           {% endif %}
         </td>
-        <td>
+        <td data-label="عملیات">
           <a href="{% url 'user_update' user.pk %}" title="ویرایش"><i class="fas fa-edit"></i></a>
           <a href="{% url 'register_face_page_for_user' user.pk %}" title="ثبت چهره"><i class="fas fa-camera"></i></a>
           <a href="{% url 'user_logs_admin' user.pk %}" title="ترددها"><i class="fas fa-list"></i></a>
@@ -51,4 +52,5 @@
     {% endfor %}
   </tbody>
 </table>
+</div>
 {% endblock %}

--- a/templates/core/my_edit_requests.html
+++ b/templates/core/my_edit_requests.html
@@ -2,7 +2,7 @@
 {% load jformat %}
 {% block title %}درخواست‌های ویرایش{% endblock %}
 {% block content %}
-<div class="card page page-md">
+<div class="card page page-lg fade-in">
   <h2 class="page-title">
     <i class="fas fa-edit" style="margin-left:0.5rem;"></i>
     درخواست‌های ویرایش {{ user.get_full_name }}
@@ -12,7 +12,7 @@
   </div>
   {% if requests %}
   <div class="table-responsive">
-  <table class="management-table">
+  <table class="management-table responsive-table">
     <thead>
       <tr>
         <th>زمان</th>

--- a/templates/core/my_leave_requests.html
+++ b/templates/core/my_leave_requests.html
@@ -2,7 +2,7 @@
 {% load jformat %}
 {% block title %}درخواست‌های مرخصی{% endblock %}
 {% block content %}
-<div class="card page page-md">
+<div class="card page page-md fade-in">
   <h2 class="page-title">
     <i class="fas fa-calendar-check" style="margin-left:0.5rem;"></i>
     درخواست‌های مرخصی {{ user.get_full_name }}
@@ -12,7 +12,7 @@
   </div>
   {% if requests %}
   <div class="table-responsive">
-  <table class="management-table">
+  <table class="management-table responsive-table">
     <thead>
       <tr>
         <th>از</th>
@@ -26,14 +26,14 @@
     <tbody>
     {% for r in requests %}
       <tr>
-        <td>{{ r.start_date|jformat:"%Y/%m/%d" }}</td>
-        <td>{{ r.end_date|jformat:"%Y/%m/%d" }}</td>
-        <td>{{ r.reason|default:"-" }}</td>
-        <td>
+        <td data-label="از">{{ r.start_date|jformat:"%Y/%m/%d" }}</td>
+        <td data-label="تا">{{ r.end_date|jformat:"%Y/%m/%d" }}</td>
+        <td data-label="توضیح">{{ r.reason|default:"-" }}</td>
+        <td data-label="وضعیت">
           {% if r.status == 'pending' %}در انتظار{% elif r.status == 'approved' %}تأیید شده{% elif r.status == 'cancelled' %}لغو شده{% else %}رد شده{% endif %}
         </td>
-        <td>{{ r.manager_note|default:"-" }}</td>
-        <td>
+        <td data-label="توضیح مدیر">{{ r.manager_note|default:"-" }}</td>
+        <td data-label="لغو">
           {% if r.status == 'pending' %}
           <form method="post" action="{% url 'cancel_leave_request' r.id %}">
             {% csrf_token %}

--- a/templates/core/user_form.html
+++ b/templates/core/user_form.html
@@ -1,17 +1,18 @@
 {% extends "core/base_management.html" %}
 {% block title %}{% if form.instance.pk %}ویرایش کاربر{% else %}افزودن کاربر{% endif %}{% endblock %}
 {% block management_content %}
-<h2 style="text-align:right;">
+<div class="card page page-sm fade-in">
+<h2 class="page-title">
   {% if form.instance.pk %}
-    <i class="fas fa-user-edit" style="margin-left:0.5rem;"></i> ویرایش کاربر
+    <i class="fas fa-user-edit"></i> ویرایش کاربر
   {% else %}
-    <i class="fas fa-user-plus" style="margin-left:0.5rem;"></i> افزودن کاربر جدید
+    <i class="fas fa-user-plus"></i> افزودن کاربر جدید
   {% endif %}
 </h2>
-<a class="btn" href="{% url 'management_users' %}" style="margin-bottom:1.1rem;">
+<a class="btn" href="{% url 'management_users' %}" style="margin-bottom:1rem;">
   <i class="fas fa-chevron-right" style="margin-left:0.4rem;"></i> بازگشت به لیست
 </a>
-<form method="post" enctype="multipart/form-data" class="card" autocomplete="off">
+<form method="post" enctype="multipart/form-data" class="form-grid" autocomplete="off">
   {% csrf_token %}
   {% for field in form %}
     <div class="form-group">
@@ -30,4 +31,5 @@
   </button>
   <a href="{% url 'management_users' %}" class="btn" style="background:var(--color-muted);color:#fff;">لغو</a>
 </form>
+</div>
 {% endblock %}

--- a/templates/core/user_list.html
+++ b/templates/core/user_list.html
@@ -1,16 +1,17 @@
 {% extends "core/base_management.html" %}
 {% block title %}لیست کاربران{% endblock %}
 {% block management_content %}
-<h2 style="text-align:right;">
-  <i class="fas fa-list" style="margin-left:0.5rem;"></i> لیست کاربران
+<h2 class="page-title">
+  <i class="fas fa-list"></i> لیست کاربران
 </h2>
 <a class="btn" href="{% url 'user_add' %}" style="margin-bottom:1.2rem;">
   <i class="fas fa-user-plus" style="margin-left:0.5rem;"></i> افزودن کاربر جدید
 </a>
-<table class="management-table">
+<div class="table-responsive">
+<table class="management-table responsive-table fade-in">
   <thead>
     <tr>
-      <th>ردیف</th>
+      <th class="hide-xs">ردیف</th>
       <th>کد پرسنلی</th>
       <th>نام</th>
       <th>نام خانوادگی</th>
@@ -22,19 +23,19 @@
   <tbody>
     {% for u in users %}
       <tr>
-        <td>{{ forloop.counter }}</td>
-        <td>{{ u.personnel_code }}</td>
-        <td>{{ u.first_name }}</td>
-        <td>{{ u.last_name }}</td>
-        <td>{{ u.username }}</td>
-        <td>
+        <td data-label="ردیف" class="hide-xs">{{ forloop.counter }}</td>
+        <td data-label="کد پرسنلی">{{ u.personnel_code }}</td>
+        <td data-label="نام">{{ u.first_name }}</td>
+        <td data-label="نام خانوادگی">{{ u.last_name }}</td>
+        <td data-label="نام کاربری">{{ u.username }}</td>
+        <td data-label="ثبت چهره">
           {% if u.face_encoding %}
             <i class="fa fa-check-circle" style="color: var(--color-secondary);"></i>
           {% else %}
             <i class="fa fa-times-circle" style="color: var(--color-error);"></i>
           {% endif %}
         </td>
-        <td>
+        <td data-label="عملیات">
           <a href="{% url 'user_update' u.pk %}" title="ویرایش"><i class="fas fa-edit"></i></a>
           <a href="{% url 'user_delete' u.pk %}" title="حذف"><i class="fas fa-trash-alt"></i></a>
         </td>
@@ -44,4 +45,5 @@
     {% endfor %}
   </tbody>
 </table>
+</div>
 {% endblock %}

--- a/templates/core/user_profile.html
+++ b/templates/core/user_profile.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% block title %}پروفایل کاربر{% endblock %}
 {% block content %}
-<div class="card page page-md profile-card">
+<div class="card page page-lg profile-card fade-in">
   <h2 class="page-title">
     <i class="fa fa-user"></i>
     پروفایل {{ user.get_full_name }}

--- a/templates/core/user_reports.html
+++ b/templates/core/user_reports.html
@@ -19,16 +19,17 @@
     با ثبت چهره
   </div>
 </div>
-<div style="margin-top:2rem;">
-  <canvas id="statusChart" height="100"></canvas>
+<div class="chart-container">
+  <canvas id="statusChart" height="120"></canvas>
 </div>
-<div style="margin-top:2rem;">
-  <canvas id="faceChart" height="100"></canvas>
+<div class="chart-container">
+  <canvas id="faceChart" height="120"></canvas>
 </div>
 <a class="btn" href="{% url 'export_logs_csv' %}" style="margin:1rem 0;display:inline-block;">
   <i class="fa fa-download" style="margin-left:0.4rem;"></i> دانلود گزارش CSV
 </a>
-<table class="management-table">
+<div class="table-responsive">
+<table class="management-table responsive-table">
   <thead>
     <tr>
       <th>کاربر</th>
@@ -41,17 +42,18 @@
   <tbody>
     {% for log in latest_logs %}
     <tr>
-      <td>{{ log.user.get_full_name }} - {{ log.user.personnel_code }}</td>
-      <td>{{ log.timestamp|jformat:"%Y/%m/%d" }}</td>
-      <td>{{ log.timestamp|time:"H:i" }}</td>
-      <td>{% if log.log_type == 'in' %}ورود{% else %}خروج{% endif %}</td>
-      <td>{% if log.source == 'self' %}کاربر{% elif log.source == 'auto' %}سیستم{% else %}مدیر{% endif %}</td>
+      <td data-label="کاربر">{{ log.user.get_full_name }} - {{ log.user.personnel_code }}</td>
+      <td data-label="تاریخ">{{ log.timestamp|jformat:"%Y/%m/%d" }}</td>
+      <td data-label="ساعت">{{ log.timestamp|time:"H:i" }}</td>
+      <td data-label="نوع">{% if log.log_type == 'in' %}ورود{% else %}خروج{% endif %}</td>
+      <td data-label="ثبت‌کننده">{% if log.source == 'self' %}کاربر{% elif log.source == 'auto' %}سیستم{% else %}مدیر{% endif %}</td>
     </tr>
     {% empty %}
     <tr><td colspan="5">ترددی ثبت نشده است.</td></tr>
     {% endfor %}
   </tbody>
 </table>
+</div>
 {% endblock %}
 
 {% block extra_js %}

--- a/templates/core/weekly_holidays.html
+++ b/templates/core/weekly_holidays.html
@@ -1,10 +1,12 @@
 {% extends "core/base_management.html" %}
 {% block title %}روزهای تعطیل{% endblock %}
 {% block management_content %}
-<h2 class="page-title"><i class="fas fa-calendar-day"></i> تنظیم روزهای تعطیل</h2>
-<form method="post" style="margin-top:1rem;">
-  {% csrf_token %}
-  {{ form.as_p }}
-  <button class="btn" type="submit">ذخیره</button>
-</form>
+<div class="card page page-sm fade-in">
+  <h2 class="page-title"><i class="fas fa-calendar-day"></i> تنظیم روزهای تعطیل</h2>
+  <form method="post" class="weekly-form" style="margin-top:1rem;">
+    {% csrf_token %}
+    {{ form.as_ul }}
+    <button class="btn" type="submit">ذخیره</button>
+  </form>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add grid-based form layout and sticky tables
- make user and management tables mobile-friendly
- style weekly holiday form with cards
- use fade-in animations on more pages
- refine profile, edit requests and attendance status pages

## Testing
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_b_687cd4a896b88329a53104b2c7a538e9