### PR TITLE
Fix forms and layout

### DIFF
--- a/attendance/views.py
+++ b/attendance/views.py
@@ -20,15 +20,16 @@ def my_logs(request):
     days = jdatetime.j_days_in_month[jm - 1]
     start_g = jdatetime.date(jy, jm, 1).togregorian()
     end_g = jdatetime.date(jy, jm, days).togregorian()
-    qs = AttendanceLog.objects.filter(user=user, timestamp__date__range=(start_g, end_g)).order_by("timestamp")
-    daily = {d: {"in": None, "out": None} for d in range(1, days + 1)}
+    qs = AttendanceLog.objects.filter(
+        user=user, timestamp__date__range=(start_g, end_g)
+    ).order_by("timestamp")
+    daily = {d: {"in": [], "out": []} for d in range(1, days + 1)}
     for log in qs:
         jd = jdatetime.date.fromgregorian(date=log.timestamp.date())
-        info = daily.get(jd.day)
-        if log.log_type == "in" and info["in"] is None:
-            info["in"] = log.timestamp.time()
-        if log.log_type == "out":
-            info["out"] = log.timestamp.time()
+        if log.log_type == "in":
+            daily[jd.day]["in"].append(log.timestamp.time())
+        else:
+            daily[jd.day]["out"].append(log.timestamp.time())
     prev_m = (jdatetime.date(jy, jm, 1) - jdatetime.timedelta(days=1))
     next_m = (jdatetime.date(jy, jm, days) + jdatetime.timedelta(days=1))
     context = {

--- a/core/views.py
+++ b/core/views.py
@@ -280,15 +280,16 @@ def my_logs(request):
     days = jdatetime.j_days_in_month[jm - 1]
     start_g = jdatetime.date(jy, jm, 1).togregorian()
     end_g = jdatetime.date(jy, jm, days).togregorian()
-    qs = AttendanceLog.objects.filter(user=u, timestamp__date__range=(start_g, end_g)).order_by("timestamp")
-    daily = {d: {"in": None, "out": None} for d in range(1, days + 1)}
+    qs = AttendanceLog.objects.filter(
+        user=u, timestamp__date__range=(start_g, end_g)
+    ).order_by("timestamp")
+    daily = {d: {"in": [], "out": []} for d in range(1, days + 1)}
     for log in qs:
         jd = jdatetime.date.fromgregorian(date=log.timestamp.date())
-        info = daily.get(jd.day)
-        if log.log_type == "in" and info["in"] is None:
-            info["in"] = log.timestamp.time()
-        if log.log_type == "out":
-            info["out"] = log.timestamp.time()
+        if log.log_type == "in":
+            daily[jd.day]["in"].append(log.timestamp.time())
+        else:
+            daily[jd.day]["out"].append(log.timestamp.time())
     prev_month_date = (jdatetime.date(jy, jm, 1) - jdatetime.timedelta(days=1))
     next_month_date = (jdatetime.date(jy, jm, days) + jdatetime.timedelta(days=1))
     context = {

--- a/static/core/global.css
+++ b/static/core/global.css
@@ -5,6 +5,11 @@
   font-style: normal;
 }
 
+/* ensure padding doesn't cause overflow */
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
 /* Mobile-first redesign */
 :root {
   --color-bg: #f7fafd;
@@ -131,6 +136,14 @@ header nav a:hover {
 }
 #main-nav.open { display: flex; }
 
+@media (max-width: 650px) {
+  #main-nav {
+    left: 0.5rem;
+    right: 0.5rem;
+    width: auto;
+  }
+}
+
 #main-content {
   flex: 1;
   width: 100%;
@@ -139,6 +152,7 @@ header nav a:hover {
   background: var(--color-surface);
   border-radius: 0;
   box-shadow: var(--shadow);
+  overflow-x: hidden;
 }
 
 .site-footer {

--- a/static/core/global.js
+++ b/static/core/global.js
@@ -34,6 +34,9 @@ document.addEventListener("DOMContentLoaded", () => {
     navToggle.addEventListener("click", () => {
       mainNav.classList.toggle("open");
     });
+    mainNav.querySelectorAll("a").forEach(link => {
+      link.addEventListener("click", () => mainNav.classList.remove("open"));
+    });
   }
 
 });

--- a/static/core/management.css
+++ b/static/core/management.css
@@ -66,7 +66,7 @@
   min-width: 0;
   min-height: 82vh;
   margin-bottom: 1rem;
-  overflow-x: auto;
+  overflow-x: hidden;
   direction: rtl;
 }
 .dashboard-stats {
@@ -204,6 +204,11 @@
   border: 1px solid var(--color-border);
   padding: 1rem 0.8rem;
 }
+
+.user-form {
+  max-width: none;
+  width: 100%;
+}
 .request-card .row {
   display: flex;
   justify-content: space-between;
@@ -218,10 +223,15 @@
   gap: 0.4rem;
   margin-top: 0.6rem;
 }
+.request-card input[type="text"],
+.management-table td input[type="text"] {
+  flex: 1 1 120px;
+  max-width: 160px;
+}
 
 /* small-screen adjustments */
 @media (max-width: 650px) {
-  .table-responsive, .management-table { display: none; }
+  .table-responsive { overflow-x: auto; }
   .request-cards { display: flex; flex-direction: column; gap: 1rem; }
 }
 

--- a/templates/attendance/my_logs.html
+++ b/templates/attendance/my_logs.html
@@ -14,8 +14,16 @@
     {% for day, info in daily_logs.items %}
     <div class="log-card fade-in">
       <span>{{ jyear }}/{{ jmonth|stringformat:"02d" }}/{{ day|stringformat:"02d" }}</span>
-      <span>{% if info.in %}{{ info.in|time:"H:i" }}{% else %}-{% endif %}</span>
-      <span>{% if info.out %}{{ info.out|time:"H:i" }}{% else %}-{% endif %}</span>
+      <span>
+        {% if info.in %}
+          {% for t in info.in %}{{ t|time:"H:i" }}{% if not forloop.last %}<br>{% endif %}{% endfor %}
+        {% else %}-{% endif %}
+      </span>
+      <span>
+        {% if info.out %}
+          {% for t in info.out %}{{ t|time:"H:i" }}{% if not forloop.last %}<br>{% endif %}{% endfor %}
+        {% else %}-{% endif %}
+      </span>
     </div>
     {% endfor %}
   </div>
@@ -28,8 +36,16 @@
         {% for day, info in daily_logs.items %}
         <tr>
           <td>{{ jyear }}/{{ jmonth|stringformat:"02d" }}/{{ day|stringformat:"02d" }}</td>
-          <td>{% if info.in %}{{ info.in|time:"H:i" }}{% else %}-{% endif %}</td>
-          <td>{% if info.out %}{{ info.out|time:"H:i" }}{% else %}-{% endif %}</td>
+          <td>
+            {% if info.in %}
+              {% for t in info.in %}{{ t|time:"H:i" }}{% if not forloop.last %}<br>{% endif %}{% endfor %}
+            {% else %}-{% endif %}
+          </td>
+          <td>
+            {% if info.out %}
+              {% for t in info.out %}{{ t|time:"H:i" }}{% if not forloop.last %}<br>{% endif %}{% endfor %}
+            {% else %}-{% endif %}
+          </td>
         </tr>
         {% endfor %}
       </tbody>

--- a/templates/core/leave_request_confirm.html
+++ b/templates/core/leave_request_confirm.html
@@ -9,6 +9,9 @@
   <form method="post">
     {% csrf_token %}
     {% for f in form.hidden_fields %}{{ f }}{% endfor %}
+    {% for f in form.visible_fields %}
+      <input type="hidden" name="{{ f.name }}" value="{{ f.value }}">
+    {% endfor %}
     <input type="hidden" name="confirm" value="1">
     <button class="btn" type="submit">ثبت</button>
   </form>

--- a/templates/core/user_form.html
+++ b/templates/core/user_form.html
@@ -11,7 +11,7 @@
 <a class="btn" href="{% url 'management_users' %}" style="margin-bottom:1.1rem;">
   <i class="fas fa-chevron-right" style="margin-left:0.4rem;"></i> بازگشت به لیست
 </a>
-<form method="post" enctype="multipart/form-data" class="card page page-sm form-grid" autocomplete="off">
+<form method="post" enctype="multipart/form-data" class="card form-grid user-form" autocomplete="off">
   {% csrf_token %}
   {% for field in form %}
     <div class="form-group">


### PR DESCRIPTION
## Summary
- add global box-sizing rule to prevent overflow
- hide horizontal scrollbars and widen admin forms
- include form fields when confirming leave requests
- expand user form width to fill the content area

## Testing
- `python manage.py check`
- `python -m py_compile attendance/views.py core/views.py`


------
https://chatgpt.com/codex/tasks/task_b_687f7efdb9a883299093b86970a22b92