### PR TITLE
Add mobile cards for management tables

### DIFF
--- a/static/core/global.js
+++ b/static/core/global.js
@@ -30,9 +30,23 @@ document.addEventListener("DOMContentLoaded", () => {
 
   const navToggle = document.getElementById("nav-toggle");
   const mainNav = document.getElementById("main-nav");
-  if (navToggle && mainNav) {
+  const sidebar = document.getElementById("management-sidebar");
+  const body = document.body;
+  const sbOverlay = document.getElementById("sidebar-overlay");
+  if (navToggle) {
     navToggle.addEventListener("click", () => {
-      mainNav.classList.toggle("open");
+      if (sidebar) {
+        sidebar.classList.toggle("open");
+        body.classList.toggle("sidebar-open");
+      } else if (mainNav) {
+        mainNav.classList.toggle("open");
+      }
+    });
+  }
+  if (sbOverlay && sidebar) {
+    sbOverlay.addEventListener("click", () => {
+      sidebar.classList.remove("open");
+      body.classList.remove("sidebar-open");
     });
   }
 

--- a/static/core/management.css
+++ b/static/core/management.css
@@ -234,7 +234,7 @@
 }
 .charts-grid canvas { flex: 0 0 220px; }
 
-@media (min-width: 900px) {
+@media (min-width: 768px) {
   .management-layout {
     flex-direction: row-reverse;
     gap: 2rem;
@@ -260,6 +260,33 @@
   .management-content {
     padding: 2.2rem 1.6rem;
     margin-bottom: 1.5rem;
+  }
+}
+
+@media (max-width: 767px) {
+  .management-sidebar {
+    position: fixed;
+    top: 0;
+    right: -250px;
+    height: 100%;
+    width: 220px;
+    max-width: 80%;
+    transition: right var(--transition);
+    z-index: 2000;
+    overflow-y: auto;
+  }
+  .management-sidebar.open {
+    right: 0;
+  }
+  .sidebar-overlay {
+    display: none;
+  }
+  body.sidebar-open .sidebar-overlay {
+    display: block;
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.4);
+    z-index: 1500;
   }
 }
 

--- a/templates/core/base.html
+++ b/templates/core/base.html
@@ -22,8 +22,10 @@
           <i class="fas fa-bars"></i>
         </button>
         <nav id="main-nav">
+          {% block header_nav_links %}
           <a href="{% url 'home' %}"><i class="fas fa-home"></i> صفحه اصلی</a>
           <a href="{% url 'logout' %}"><i class="fas fa-sign-out-alt"></i> خروج</a>
+          {% endblock %}
         </nav>
       {% endif %}
     </div>

--- a/templates/core/base_management.html
+++ b/templates/core/base_management.html
@@ -1,13 +1,17 @@
 {% extends "core/base.html" %}
 {% load static %}
+{% block header_nav_links %}
+  <a href="{% url 'home' %}"><i class="fas fa-home"></i> صفحه اصلی</a>
+{% endblock %}
 {% block extra_css %}
 <link rel="stylesheet" href="{% static 'core/management.css' %}">
 {% endblock %}
 {% block content %}
 <div class="management-layout">
-  <aside class="management-sidebar">
+  <aside id="management-sidebar" class="management-sidebar">
     <div class="sidebar-title">پنل مدیریت</div>
     <nav>
+      <a href="{% url 'home' %}"><i class="fas fa-home"></i> صفحه اصلی</a>
       <a href="{% url 'management_dashboard' %}" class="{% if request.resolver_match.url_name == 'management_dashboard' %}active{% endif %}">
         <i class="fas fa-chart-pie"></i> داشبورد
       </a>
@@ -32,10 +36,12 @@
         <a href="{% url 'weekly_holidays' %}" class="{% if request.resolver_match.url_name == 'weekly_holidays' %}active{% endif %}">
           <i class="fas fa-calendar-day"></i> تعطیلات هفتگی
         </a>
+        <a href="{% url 'logout' %}"><i class="fas fa-sign-out-alt"></i> خروج</a>
       </nav>
   </aside>
   <section class="management-content">
     {% block management_content %}{% endblock %}
   </section>
 </div>
+<div id="sidebar-overlay" class="sidebar-overlay"></div>
 {% endblock %}

--- a/templates/core/management_users.html
+++ b/templates/core/management_users.html
@@ -8,47 +8,76 @@
 <a class="btn" href="{% url 'user_add' %}" style="margin-bottom:1.4rem;">
   <i class="fas fa-user-plus" style="margin-left:0.5rem;"></i> افزودن کاربر جدید
 </a>
-<table class="management-table">
-  <thead>
-    <tr>
-      <th>ردیف</th>
-      <th>کد پرسنلی</th>
-      <th>نام و نام خانوادگی</th>
-      <th>وضعیت</th>
-      <th>ثبت چهره</th>
-      <th>عملیات</th>
-    </tr>
-  </thead>
-  <tbody>
-    {% for user in users %}
+<div class="request-cards">
+  {% for user in users %}
+  <div class="request-card fade-in">
+    <div class="row"><span class="label">کد پرسنلی:</span><span>{{ user.personnel_code }}</span></div>
+    <div class="row"><span class="label">نام و نام خانوادگی:</span><span>{{ user.get_full_name }}</span></div>
+    <div class="row"><span class="label">وضعیت:</span>
+      <span>{% if user.is_active %}فعال{% else %}غیرفعال{% endif %}</span>
+    </div>
+    <div class="row"><span class="label">ثبت چهره:</span>
+      {% if user.face_encoding %}
+        <i class="fa fa-check-circle" style="color: var(--color-secondary);"></i>
+      {% else %}
+        <i class="fa fa-times-circle" style="color: var(--color-error);"></i>
+      {% endif %}
+    </div>
+    <div class="actions">
+      <a href="{% url 'user_update' user.pk %}" class="btn" style="font-size:0.9rem;">ویرایش</a>
+      <a href="{% url 'register_face_page_for_user' user.pk %}" class="btn" style="font-size:0.9rem;"><i class="fas fa-camera"></i></a>
+      <a href="{% url 'user_logs_admin' user.pk %}" class="btn" style="font-size:0.9rem;background:var(--color-muted);">ترددها</a>
+      <a href="{% url 'user_delete' user.pk %}" class="btn btn-danger" style="font-size:0.9rem;">حذف</a>
+    </div>
+  </div>
+  {% empty %}
+  <div class="alert-error">هیچ کاربری یافت نشد</div>
+  {% endfor %}
+</div>
+
+<div class="table-responsive">
+  <table class="management-table">
+    <thead>
       <tr>
-        <td>{{ forloop.counter }}</td>
-        <td>{{ user.personnel_code }}</td>
-        <td>{{ user.get_full_name }}</td>
-        <td>
-          {% if user.is_active %}
-            <span class="alert-success" style="padding:0.15rem 0.4rem;font-size:0.95em;">فعال</span>
-          {% else %}
-            <span class="alert-error" style="padding:0.15rem 0.4rem;font-size:0.95em;">غیرفعال</span>
-          {% endif %}
-        </td>
-        <td>
-          {% if user.face_encoding %}
-            <i class="fa fa-check-circle" style="color: var(--color-secondary);"></i>
-          {% else %}
-            <i class="fa fa-times-circle" style="color: var(--color-error);"></i>
-          {% endif %}
-        </td>
-        <td>
-          <a href="{% url 'user_update' user.pk %}" title="ویرایش"><i class="fas fa-edit"></i></a>
-          <a href="{% url 'register_face_page_for_user' user.pk %}" title="ثبت چهره"><i class="fas fa-camera"></i></a>
-          <a href="{% url 'user_logs_admin' user.pk %}" title="ترددها"><i class="fas fa-list"></i></a>
-          <a href="{% url 'user_delete' user.pk %}" title="حذف"><i class="fas fa-trash-alt"></i></a>
-        </td>
+        <th>ردیف</th>
+        <th>کد پرسنلی</th>
+        <th>نام و نام خانوادگی</th>
+        <th>وضعیت</th>
+        <th>ثبت چهره</th>
+        <th>عملیات</th>
       </tr>
-    {% empty %}
-      <tr><td colspan="6">هیچ کاربری یافت نشد</td></tr>
-    {% endfor %}
-  </tbody>
-</table>
+    </thead>
+    <tbody>
+      {% for user in users %}
+        <tr>
+          <td>{{ forloop.counter }}</td>
+          <td>{{ user.personnel_code }}</td>
+          <td>{{ user.get_full_name }}</td>
+          <td>
+            {% if user.is_active %}
+              <span class="alert-success" style="padding:0.15rem 0.4rem;font-size:0.95em;">فعال</span>
+            {% else %}
+              <span class="alert-error" style="padding:0.15rem 0.4rem;font-size:0.95em;">غیرفعال</span>
+            {% endif %}
+          </td>
+          <td>
+            {% if user.face_encoding %}
+              <i class="fa fa-check-circle" style="color: var(--color-secondary);"></i>
+            {% else %}
+              <i class="fa fa-times-circle" style="color: var(--color-error);"></i>
+            {% endif %}
+          </td>
+          <td>
+            <a href="{% url 'user_update' user.pk %}" title="ویرایش"><i class="fas fa-edit"></i></a>
+            <a href="{% url 'register_face_page_for_user' user.pk %}" title="ثبت چهره"><i class="fas fa-camera"></i></a>
+            <a href="{% url 'user_logs_admin' user.pk %}" title="ترددها"><i class="fas fa-list"></i></a>
+            <a href="{% url 'user_delete' user.pk %}" title="حذف"><i class="fas fa-trash-alt"></i></a>
+          </td>
+        </tr>
+      {% empty %}
+        <tr><td colspan="6">هیچ کاربری یافت نشد</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
 {% endblock %}

--- a/templates/core/suspicious_logs.html
+++ b/templates/core/suspicious_logs.html
@@ -6,26 +6,41 @@
   <i class="fas fa-exclamation-triangle"></i>
   تشخیص‌های مشکوک
 </h2>
-<table class="management-table">
-  <thead>
-    <tr>
-      <th>کاربر پیشنهادی</th>
-      <th>فاصله</th>
-      <th>زمان</th>
-      <th>تصویر</th>
-    </tr>
-  </thead>
-  <tbody>
-    {% for log in logs %}
-    <tr>
-      <td>{% if log.matched_user %}{{ log.matched_user.get_full_name }} - {{ log.matched_user.personnel_code }}{% else %}نامشخص{% endif %}</td>
-      <td>{{ log.similarity|floatformat:3 }}</td>
-      <td>{{ log.timestamp|jformat:"%Y/%m/%d %H:%M" }}</td>
-      <td>{% if log.image %}<img src="{{ log.image.url }}" height="40">{% else %}-{% endif %}</td>
-    </tr>
-    {% empty %}
-    <tr><td colspan="4">موردی ثبت نشده است.</td></tr>
-    {% endfor %}
-  </tbody>
-</table>
+<div class="request-cards">
+  {% for log in logs %}
+  <div class="request-card fade-in">
+    <div class="row"><span class="label">کاربر پیشنهادی:</span><span>{% if log.matched_user %}{{ log.matched_user.get_full_name }} - {{ log.matched_user.personnel_code }}{% else %}نامشخص{% endif %}</span></div>
+    <div class="row"><span class="label">فاصله:</span><span>{{ log.similarity|floatformat:3 }}</span></div>
+    <div class="row"><span class="label">زمان:</span><span>{{ log.timestamp|jformat:"%Y/%m/%d %H:%M" }}</span></div>
+    <div class="row"><span class="label">تصویر:</span><span>{% if log.image %}<img src="{{ log.image.url }}" height="40">{% else %}-{% endif %}</span></div>
+  </div>
+  {% empty %}
+  <div class="alert-error">موردی ثبت نشده است.</div>
+  {% endfor %}
+</div>
+
+<div class="table-responsive">
+  <table class="management-table">
+    <thead>
+      <tr>
+        <th>کاربر پیشنهادی</th>
+        <th>فاصله</th>
+        <th>زمان</th>
+        <th>تصویر</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for log in logs %}
+      <tr>
+        <td>{% if log.matched_user %}{{ log.matched_user.get_full_name }} - {{ log.matched_user.personnel_code }}{% else %}نامشخص{% endif %}</td>
+        <td>{{ log.similarity|floatformat:3 }}</td>
+        <td>{{ log.timestamp|jformat:"%Y/%m/%d %H:%M" }}</td>
+        <td>{% if log.image %}<img src="{{ log.image.url }}" height="40">{% else %}-{% endif %}</td>
+      </tr>
+      {% empty %}
+      <tr><td colspan="4">موردی ثبت نشده است.</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
 {% endblock %}

--- a/templates/core/user_reports.html
+++ b/templates/core/user_reports.html
@@ -26,6 +26,19 @@
 <a class="btn" href="{% url 'export_logs_csv' %}" style="margin:1rem 0;display:inline-block;">
   <i class="fa fa-download" style="margin-left:0.4rem;"></i> دانلود گزارش CSV
 </a>
+<div class="request-cards">
+  {% for log in latest_logs %}
+  <div class="request-card fade-in">
+    <div class="row"><span class="label">کاربر:</span><span>{{ log.user.get_full_name }} - {{ log.user.personnel_code }}</span></div>
+    <div class="row"><span class="label">تاریخ:</span><span>{{ log.timestamp|jformat:"%Y/%m/%d" }}</span></div>
+    <div class="row"><span class="label">ساعت:</span><span>{{ log.timestamp|time:"H:i" }}</span></div>
+    <div class="row"><span class="label">نوع:</span><span>{% if log.log_type == 'in' %}ورود{% else %}خروج{% endif %}</span></div>
+    <div class="row"><span class="label">ثبت‌کننده:</span><span>{% if log.source == 'self' %}کاربر{% elif log.source == 'auto' %}سیستم{% else %}مدیر{% endif %}</span></div>
+  </div>
+  {% empty %}
+  <div class="alert-error">ترددی ثبت نشده است.</div>
+  {% endfor %}
+</div>
 <div class="table-responsive">
 <table class="management-table">
   <thead>


### PR DESCRIPTION
## Summary
- add card layout and table wrappers for user management list
- show cards for suspicious logs and reports on mobile
- implement responsive sidebar with hamburger menu for management pages

## Testing
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_b_687fc12421f48329b97fd10682a989ce