### PR TITLE
Improve large screen layout

### DIFF
--- a/static/core/global.css
+++ b/static/core/global.css
@@ -357,7 +357,7 @@ label {
 @media (min-width: 800px) {
   .header-inner,
   #main-content {
-    max-width: 950px;
+    max-width: 1200px;
     margin: 0 auto;
     padding: 1.5rem 1rem;
     border-radius: var(--radius);


### PR DESCRIPTION
## Summary
- expand `#main-content` and `.header-inner` width for desktop screens

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688b3f5b486483339a5f6bee1a4467fa