### PR TITLE
Improve responsive header and management navigation

### DIFF
--- a/static/core/global.css
+++ b/static/core/global.css
@@ -70,32 +70,29 @@ body {
   display: flex;
   align-items: center;
   gap: 0.6rem;
-  justify-content: space-between;
-}
-
-.site-logo {
-  width: 44px;
-  height: 44px;
-  border-radius: 50%;
-  background: #fff;
-  box-shadow: var(--shadow);
-  object-fit: cover;
-  margin-left: 0.7rem;
+  justify-content: flex-start;
+  position: relative;
 }
 
 .site-title {
   font-size: 1.3rem;
   font-weight: 700;
   color: #fff;
-  margin-left: 1.5rem;
+  margin: 0;
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
 }
 
 .nav-toggle {
   display: block;
-  background: none;
+  background: #fff;
   border: none;
-  color: #fff;
-  font-size: 1.4rem;
+  color: var(--color-primary-dark);
+  font-size: 1.2rem;
+  width: 32px;
+  height: 32px;
+  border-radius: 0.4rem;
   cursor: pointer;
 }
 
@@ -128,13 +125,38 @@ header nav a:hover {
   flex-direction: column;
   gap: 0.6rem;
   min-width: 160px;
+  order: -1;
 }
 #main-nav.open { display: flex; }
+
+.mobile-only { display: block; }
+.desktop-only { display: none; }
+
+@media (min-width: 768px) {
+  .nav-toggle { display: none; }
+  #main-nav {
+    display: flex;
+    position: static;
+    background: none;
+    box-shadow: none;
+    padding: 0;
+    flex-direction: row;
+    gap: 1rem;
+  }
+  header nav a {
+    color: #fff;
+  }
+  header nav a:hover {
+    color: #e0e0e0;
+  }
+  .mobile-only { display: none; }
+  .desktop-only { display: block; }
+}
 
 #main-content {
   flex: 1;
   width: 100%;
-  margin: 1rem 0 0 0;
+  margin: 0.6rem 0 0 0;
   padding: 1rem 0.5rem;
   background: var(--color-surface);
   border-radius: 0;
@@ -362,7 +384,6 @@ label {
     padding: 1.5rem 1rem;
     border-radius: var(--radius);
   }
-  .site-logo { width: 44px; height: 44px; }
   .site-title { font-size: 1.3rem; }
   .nav-toggle { display: none; }
   #main-nav {

--- a/static/core/management.css
+++ b/static/core/management.css
@@ -47,15 +47,6 @@
     padding: 1.5rem 0.8rem !important;
   }
 }
-.management-sidebar .sidebar-logo {
-  width: 60px;
-  height: 60px;
-  object-fit: contain;
-  border-radius: 1rem;
-  background: #fff;
-  margin: 0 auto 1.7rem auto;
-  display: block;
-}
 .management-sidebar .sidebar-title {
   text-align: center;
   font-weight: 600;
@@ -115,6 +106,13 @@
 }
 .management-sidebar .sub-menu a {
   font-size: 1rem;
+}
+
+.management-sidebar .sidebar-footer {
+  margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
 }
 .management-content {
   flex: 1;
@@ -309,9 +307,6 @@
     min-height: 88vh;
     margin-left: 1.1rem;
     margin-bottom: 0;
-  }
-  .management-sidebar .sidebar-logo {
-    margin: 0 auto 1.7rem auto;
   }
   .management-sidebar nav {
     flex-direction: column;

--- a/templates/core/base.html
+++ b/templates/core/base.html
@@ -7,7 +7,6 @@
   <title>{% block title %}سامانه تردد{% endblock %}</title>
   <link rel="stylesheet" href="{% static 'core/global.css' %}" />
   <link rel="stylesheet" href="{% static 'fonts/vazir.ttf' %}" as="font" type="font/ttf" crossorigin />
-  <link rel="shortcut icon" href="{% static 'core/logo.png' %}">
   <!-- Font Awesome -->
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" />
   {% block extra_css %}{% endblock %}
@@ -15,12 +14,13 @@
 <body>
   <header class="site-header">
     <div class="header-inner">
-      <img src="{% static 'core/logo.png' %}" alt="لوگو" class="site-logo" />
-      <span class="site-title">سامانه تردد هوشمند</span>
       {% if user.is_authenticated %}
         <button class="nav-toggle" id="nav-toggle" aria-label="نمایش منو">
-          <i class="fas fa-bars"></i>
+          <i class="fas fa-list"></i>
         </button>
+      {% endif %}
+      <span class="site-title">سامانه تردد</span>
+      {% if user.is_authenticated %}
         <nav id="main-nav">
           {% block nav_links %}
           <a href="{% url 'home' %}"><i class="fas fa-home"></i> صفحه اصلی</a>

--- a/templates/core/base_management.html
+++ b/templates/core/base_management.html
@@ -3,9 +3,6 @@
 {% block extra_css %}
 <link rel="stylesheet" href="{% static 'core/management.css' %}">
 {% endblock %}
-{% block nav_links %}
-<a href="{% url 'home' %}"><i class="fas fa-home"></i> صفحه اصلی</a>
-{% endblock %}
 {% block content %}
 <div class="management-layout">
   <div id="sidebar-overlay" class="sidebar-overlay"></div>
@@ -45,7 +42,10 @@
           <a href="{% url 'device_settings' %}" class="{% if request.resolver_match.url_name == 'device_settings' %}active{% endif %}">دستگاه</a>
         </nav>
       </details>
-      <a href="{% url 'logout' %}"><i class="fas fa-sign-out-alt"></i> خروج</a>
+      <div class="sidebar-footer mobile-only">
+        <a href="{% url 'home' %}"><i class="fas fa-home"></i> صفحه اصلی</a>
+        <a href="{% url 'logout' %}"><i class="fas fa-sign-out-alt"></i> خروج</a>
+      </div>
       </nav>
   </aside>
   <section class="management-content">

--- a/templates/core/home.html
+++ b/templates/core/home.html
@@ -1,9 +1,9 @@
 {% extends "core/base.html" %}
-{% block title %}سامانه تردد هوشمند{% endblock %}
+{% block title %}سامانه تردد{% endblock %}
 {% block content %}
 <div class="card page page-sm" style="margin-top:3.7rem;text-align:right;">
   <h2 class="page-title">
-    <i class="fas fa-id-card"></i> سامانه تردد هوشمند
+    <i class="fas fa-id-card"></i> سامانه تردد
   </h2>
   <div style="display:flex;flex-direction:column;gap:1.1rem;">
     <a class="btn" href="{% url 'management_login' %}">


### PR DESCRIPTION
## Summary
- center site title and display home/logout links in desktop header
- show home and logout at bottom of management sidebar on mobile
- add small spacing between header and main content

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6890a73ad5c08333a213ecd8d25999ad