### PR TITLE
Responsive management header and navigation

### DIFF
--- a/static/core/global.css
+++ b/static/core/global.css
@@ -19,6 +19,7 @@
   --radius: 1.2rem;
   --shadow: 0 4px 16px rgba(0,0,0,0.06);
   --transition: 0.2s cubic-bezier(.4,0,.2,1);
+  --header-height: 3.5rem;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -55,12 +56,14 @@ body {
   flex-direction: column;
 }
 
+
 .site-header {
   background: linear-gradient(90deg, var(--color-primary) 0%, var(--color-primary-dark) 100%);
   color: #fff;
   box-shadow: var(--shadow);
   padding: 0.6rem 0;
   position: relative;
+  height: var(--header-height);
 }
 
 .header-inner {
@@ -70,66 +73,54 @@ body {
   display: flex;
   align-items: center;
   gap: 0.6rem;
-  justify-content: space-between;
-}
-
-.site-logo {
-  width: 44px;
-  height: 44px;
-  border-radius: 50%;
-  background: #fff;
-  box-shadow: var(--shadow);
-  object-fit: cover;
-  margin-left: 0.7rem;
+  justify-content: center;
+  position: relative;
 }
 
 .site-title {
   font-size: 1.3rem;
   font-weight: 700;
   color: #fff;
-  margin-left: 1.5rem;
+  margin: 0 auto;
+  text-align: center;
 }
 
 .nav-toggle {
-  display: block;
-  background: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
   border: none;
   color: #fff;
-  font-size: 1.4rem;
+  font-size: 1.5rem;
+  padding: 0.2rem;
   cursor: pointer;
-}
-
-header nav {
-  display: none;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.6rem;
-}
-header nav a {
-  color: var(--color-primary);
-  margin: 0;
-  font-weight: 500;
-  text-decoration: none;
-  transition: color var(--transition);
-}
-header nav a:hover {
-  color: var(--color-primary-dark);
-}
-
-#main-nav {
   position: absolute;
-  top: 100%;
   right: 0.5rem;
-  background: var(--color-surface);
-  border-radius: 0.6rem;
-  box-shadow: var(--shadow);
-  padding: 0.7rem 1rem;
-  display: none;
-  flex-direction: column;
-  gap: 0.6rem;
-  min-width: 160px;
+  top: 50%;
+  transform: translateY(-50%);
 }
-#main-nav.open { display: flex; }
+
+.nav-toggle.open { color: var(--color-secondary); }
+
+.header-link {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  color: #fff;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.header-home { right: 0.5rem; }
+.header-logout { left: 0.5rem; }
+
+.desktop-only { display: none; }
+
+@media (min-width: 900px) {
+  .nav-toggle { display: none; }
+  .desktop-only { display: block; }
+}
 
 #main-content {
   flex: 1;
@@ -362,20 +353,7 @@ label {
     padding: 1.5rem 1rem;
     border-radius: var(--radius);
   }
-  .site-logo { width: 44px; height: 44px; }
   .site-title { font-size: 1.3rem; }
-  .nav-toggle { display: none; }
-  #main-nav {
-    position: static;
-    background: none;
-    box-shadow: none;
-    padding: 0;
-    display: flex;
-    flex-direction: row;
-    gap: 0;
-  }
-  header nav a { color: #fff; margin-left: 1rem; }
-  #main-nav.open a { margin-left: 1rem; }
 }
 
 @media (max-width: 650px) {

--- a/static/core/global.js
+++ b/static/core/global.js
@@ -33,12 +33,24 @@ document.addEventListener("DOMContentLoaded", () => {
   const sidebar = document.getElementById("management-sidebar");
   const sidebarOverlay = document.getElementById("sidebar-overlay");
   if (navToggle) {
+    const icon = navToggle.querySelector("i");
     navToggle.addEventListener("click", () => {
+      navToggle.classList.toggle("open");
       if (sidebar) {
-        sidebar.classList.toggle("open");
-        if (sidebarOverlay) sidebarOverlay.classList.toggle("open");
+        const isOpen = sidebar.classList.toggle("open");
+        if (sidebarOverlay) sidebarOverlay.classList.toggle("open", isOpen);
+        navToggle.setAttribute("aria-expanded", isOpen);
+        if (icon) {
+          icon.classList.toggle("fa-bars", !isOpen);
+          icon.classList.toggle("fa-times", isOpen);
+        }
       } else if (mainNav) {
-        mainNav.classList.toggle("open");
+        const isOpen = mainNav.classList.toggle("open");
+        navToggle.setAttribute("aria-expanded", isOpen);
+        if (icon) {
+          icon.classList.toggle("fa-bars", !isOpen);
+          icon.classList.toggle("fa-times", isOpen);
+        }
       }
     });
   }
@@ -46,6 +58,15 @@ document.addEventListener("DOMContentLoaded", () => {
     sidebarOverlay.addEventListener("click", () => {
       sidebar.classList.remove("open");
       sidebarOverlay.classList.remove("open");
+      if (navToggle) {
+        navToggle.classList.remove("open");
+        navToggle.setAttribute("aria-expanded", "false");
+        const icon = navToggle.querySelector("i");
+        if (icon) {
+          icon.classList.add("fa-bars");
+          icon.classList.remove("fa-times");
+        }
+      }
     });
   }
 

--- a/static/core/management.css
+++ b/static/core/management.css
@@ -27,11 +27,11 @@
   gap: 1rem;
   direction: ltr;
   position: fixed;
-  top: 0;
+  top: calc(var(--header-height) + 0.5rem);
   right: 0;
   width: 220px;
   max-width: 85vw;
-  height: 100vh;
+  height: calc(100vh - var(--header-height) - 0.5rem);
   overflow-y: auto;
   transform: translateX(100%);
   transition: transform var(--transition);
@@ -46,15 +46,6 @@
     margin: 0 !important;
     padding: 1.5rem 0.8rem !important;
   }
-}
-.management-sidebar .sidebar-logo {
-  width: 60px;
-  height: 60px;
-  object-fit: contain;
-  border-radius: 1rem;
-  background: #fff;
-  margin: 0 auto 1.7rem auto;
-  display: block;
 }
 .management-sidebar .sidebar-title {
   text-align: center;
@@ -127,6 +118,12 @@
   margin-bottom: 1rem;
   overflow-x: visible;
   direction: rtl;
+}
+
+@media (min-width: 900px) {
+  .mobile-only {
+    display: none !important;
+  }
 }
 .dashboard-stats {
   display: grid;
@@ -309,9 +306,6 @@
     min-height: 88vh;
     margin-left: 1.1rem;
     margin-bottom: 0;
-  }
-  .management-sidebar .sidebar-logo {
-    margin: 0 auto 1.7rem auto;
   }
   .management-sidebar nav {
     flex-direction: column;

--- a/templates/core/base.html
+++ b/templates/core/base.html
@@ -7,7 +7,6 @@
   <title>{% block title %}سامانه تردد{% endblock %}</title>
   <link rel="stylesheet" href="{% static 'core/global.css' %}" />
   <link rel="stylesheet" href="{% static 'fonts/vazir.ttf' %}" as="font" type="font/ttf" crossorigin />
-  <link rel="shortcut icon" href="{% static 'core/logo.png' %}">
   <!-- Font Awesome -->
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" />
   {% block extra_css %}{% endblock %}
@@ -15,19 +14,14 @@
 <body>
   <header class="site-header">
     <div class="header-inner">
-      <img src="{% static 'core/logo.png' %}" alt="لوگو" class="site-logo" />
-      <span class="site-title">سامانه تردد هوشمند</span>
       {% if user.is_authenticated %}
-        <button class="nav-toggle" id="nav-toggle" aria-label="نمایش منو">
+        <button class="nav-toggle" id="nav-toggle" aria-label="باز کردن منو" aria-expanded="false">
           <i class="fas fa-bars"></i>
         </button>
-        <nav id="main-nav">
-          {% block nav_links %}
-          <a href="{% url 'home' %}"><i class="fas fa-home"></i> صفحه اصلی</a>
-          <a href="{% url 'logout' %}"><i class="fas fa-sign-out-alt"></i> خروج</a>
-          {% endblock %}
-        </nav>
+        <a href="{% url 'home' %}" class="header-link desktop-only header-home"><i class="fas fa-home"></i> صفحه اصلی</a>
+        <a href="{% url 'logout' %}" class="header-link desktop-only header-logout"><i class="fas fa-sign-out-alt"></i> خروج</a>
       {% endif %}
+      <span class="site-title">سامانه تردد</span>
     </div>
   </header>
   <main id="main-content">

--- a/templates/core/base_management.html
+++ b/templates/core/base_management.html
@@ -3,9 +3,6 @@
 {% block extra_css %}
 <link rel="stylesheet" href="{% static 'core/management.css' %}">
 {% endblock %}
-{% block nav_links %}
-<a href="{% url 'home' %}"><i class="fas fa-home"></i> صفحه اصلی</a>
-{% endblock %}
 {% block content %}
 <div class="management-layout">
   <div id="sidebar-overlay" class="sidebar-overlay"></div>
@@ -41,11 +38,12 @@
         <nav class="sub-menu">
           <a href="{% url 'shift_list' %}" class="{% if request.resolver_match.url_name == 'shift_list' or request.resolver_match.url_name == 'shift_add' or request.resolver_match.url_name == 'shift_edit' %}active{% endif %}">شیفت‌ها</a>
           <a href="{% url 'group_list' %}" class="{% if request.resolver_match.url_name == 'group_list' or request.resolver_match.url_name == 'group_add' or request.resolver_match.url_name == 'group_edit' %}active{% endif %}">گروه‌ها</a>
-          <a href="{% url 'leave_type_list' %}" class="{% if request.resolver_match.url_name == 'leave_type_list' or request.resolver_match.url_name == 'leave_type_add' or request.resolver_match.url_name == 'leave_type_edit' %}active{% endif %}">انواع مرخصی</a>
+        <a href="{% url 'leave_type_list' %}" class="{% if request.resolver_match.url_name == 'leave_type_list' or request.resolver_match.url_name == 'leave_type_add' or request.resolver_match.url_name == 'leave_type_edit' %}active{% endif %}">انواع مرخصی</a>
           <a href="{% url 'device_settings' %}" class="{% if request.resolver_match.url_name == 'device_settings' %}active{% endif %}">دستگاه</a>
         </nav>
       </details>
-      <a href="{% url 'logout' %}"><i class="fas fa-sign-out-alt"></i> خروج</a>
+      <a href="{% url 'home' %}" class="mobile-only"><i class="fas fa-home"></i> صفحه اصلی</a>
+      <a href="{% url 'logout' %}" class="mobile-only"><i class="fas fa-sign-out-alt"></i> خروج</a>
       </nav>
   </aside>
   <section class="management-content">

--- a/templates/core/home.html
+++ b/templates/core/home.html
@@ -1,9 +1,9 @@
 {% extends "core/base.html" %}
-{% block title %}سامانه تردد هوشمند{% endblock %}
+{% block title %}سامانه تردد{% endblock %}
 {% block content %}
 <div class="card page page-sm" style="margin-top:3.7rem;text-align:right;">
   <h2 class="page-title">
-    <i class="fas fa-id-card"></i> سامانه تردد هوشمند
+    <i class="fas fa-id-card"></i> سامانه تردد
   </h2>
   <div style="display:flex;flex-direction:column;gap:1.1rem;">
     <a class="btn" href="{% url 'management_login' %}">


### PR DESCRIPTION
## Summary
- Arrange dashboard header with home link on the right and logout on the left around the centered title
- Simplify navigation by replacing desktop header menu with direct links styled for desktop only
- Refine mobile hamburger menu with transparent styling and icon toggling for better responsiveness

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6890a73ad5c08333a213ecd8d25999ad