### PR TITLE
Add manual attendance log option and improve user pages

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -198,18 +198,34 @@ class AttendanceStatusForm(forms.Form):
     )
 
 
+class ManualLogForm(forms.Form):
+    """Form for managers to manually add an attendance log."""
+    user = forms.ModelChoiceField(label="کاربر", queryset=User.objects.all())
+    timestamp = forms.DateTimeField(
+        label="زمان",
+        widget=forms.DateTimeInput(attrs={"type": "datetime-local"}),
+    )
+    log_type = forms.ChoiceField(label="نوع", choices=LOG_TYPE_CHOICES)
+
+
 class UserLogsRangeForm(forms.Form):
-    start = jforms.jDateField(label="از تاریخ", widget=AdminjDateWidget())
-    end = jforms.jDateField(label="تا تاریخ", widget=AdminjDateWidget())
+    start = forms.DateField(
+        label="از تاریخ",
+        widget=forms.DateInput(attrs={"type": "date"}),
+    )
+    end = forms.DateField(
+        label="تا تاریخ",
+        widget=forms.DateInput(attrs={"type": "date"}),
+    )
 
     def clean(self):
         cleaned = super().clean()
         sd = cleaned.get("start")
         ed = cleaned.get("end")
         if sd:
-            cleaned["start_g"] = sd.togregorian()
+            cleaned["start_g"] = sd
         if ed:
-            cleaned["end_g"] = ed.togregorian()
+            cleaned["end_g"] = ed
         if sd and ed and cleaned["end_g"] < cleaned["start_g"]:
             self.add_error("end", "بازه نامعتبر است")
         return cleaned

--- a/core/urls.py
+++ b/core/urls.py
@@ -14,6 +14,7 @@ urlpatterns = [
     path('management/reports/', views.user_reports, name='management_reports'),
     path('management/suspicions/', views.suspicious_logs, name='suspicious_logs'),
     path('management/edit-requests/', views.edit_requests, name='edit_requests'),
+    path('management/manual-log/', views.manual_log, name='manual_log'),
     path('management/leave-requests/', views.leave_requests, name='leave_requests'),
     path('management/leave-requests/add/', views.add_leave, name='add_leave'),
     path('management/logs/export/', views.export_logs_csv, name='export_logs_csv'),

--- a/core/views.py
+++ b/core/views.py
@@ -38,6 +38,7 @@ from core.forms import (
     EditRequestForm,
     LeaveRequestForm,
     ManualLeaveForm,
+    ManualLogForm,
     AttendanceStatusForm,
     UserLogsRangeForm,
     WeeklyHolidayForm,
@@ -925,6 +926,32 @@ def edit_requests(request):
             "selected_group": group_id,
             "selected_shift": shift_id,
         },
+    )
+
+
+@login_required
+@staff_required
+def manual_log(request):
+    """Allow admin to manually register an attendance log for a user."""
+    if not request.session.get("face_verified"):
+        return redirect("management_face_check")
+    if request.method == "POST":
+        form = ManualLogForm(request.POST)
+        if form.is_valid():
+            AttendanceLog.objects.create(
+                user=form.cleaned_data["user"],
+                timestamp=form.cleaned_data["timestamp"],
+                log_type=form.cleaned_data["log_type"],
+                source="manual",
+            )
+            messages.success(request, "تردد ثبت شد.")
+            return redirect("edit_requests")
+    else:
+        form = ManualLogForm()
+    return render(
+        request,
+        "core/manual_log_form.html",
+        {"form": form, "active_tab": "edit_requests"},
     )
 
 

--- a/static/core/global.css
+++ b/static/core/global.css
@@ -240,7 +240,7 @@ label {
 
 /* wrapper for horizontal scroll when needed */
 .table-responsive {
-  overflow-x: visible;
+  overflow-x: auto;
 }
 
 /* profile page tweaks */
@@ -411,23 +411,7 @@ label {
   .form-grid { grid-template-columns: repeat(2, 1fr); }
 }
 
-/* card layout for personal logs */
-.log-cards { display: none; }
-.log-card {
-  background: var(--color-bg);
-  border-radius: var(--radius);
-  box-shadow: var(--shadow);
-  border: 1px solid var(--color-border);
-  padding: 0.8rem;
-  display: flex;
-  justify-content: space-between;
-  font-size: 0.95rem;
-}
-.log-card span:first-child { color: var(--color-muted); }
-@media (max-width: 650px) {
-  .log-cards { display: flex; flex-direction: column; gap: 0.6rem; }
-  .table-responsive, .management-table { display: none; }
-}
+
 /* badges for request and status labels */
 .badge {
   display: inline-block;

--- a/templates/attendance/my_logs.html
+++ b/templates/attendance/my_logs.html
@@ -10,15 +10,6 @@
     <span style="margin:0 1rem;">{{ jyear }}/{{ jmonth }}</span>
     <a class="btn" href="?month={{ next_month }}">ماه بعد <i class="fas fa-chevron-left"></i></a>
   </div>
-  <div class="log-cards">
-    {% for day, info in daily_logs.items %}
-    <div class="log-card fade-in">
-      <span>{{ jyear }}/{{ jmonth|stringformat:"02d" }}/{{ day|stringformat:"02d" }}</span>
-      <span>{% if info.in %}{{ info.in|time:"H:i" }}{% else %}-{% endif %}</span>
-      <span>{% if info.out %}{{ info.out|time:"H:i" }}{% else %}-{% endif %}</span>
-    </div>
-    {% endfor %}
-  </div>
   <div class="table-responsive">
     <table class="management-table">
       <thead>
@@ -39,7 +30,7 @@
     <a class="btn" href="{% url 'export_my_logs_csv' %}" style="margin-left:0.5rem;"><i class="fa fa-download" style="margin-left:0.4rem;"></i> دریافت CSV</a>
     <a class="btn" href="{% url 'edit_request' %}" style="margin-left:0.5rem;"><i class="fa fa-edit" style="margin-left:0.4rem;"></i> درخواست ویرایش</a>
     <a class="btn" href="{% url 'user_edit_requests' %}" style="margin-left:0.5rem;"><i class="fa fa-list" style="margin-left:0.4rem;"></i> درخواست‌های ویرایش</a>
-    <a class="btn" href="{% url 'user_inquiry' %}"><i class="fas fa-chevron-right" style="margin-left:0.4rem;"></i> بازگشت</a>
+    <a class="btn" href="{% url 'user_profile' %}"><i class="fas fa-chevron-right" style="margin-left:0.4rem;"></i> بازگشت</a>
   </div>
 </div>
 {% endblock %}

--- a/templates/core/device_settings.html
+++ b/templates/core/device_settings.html
@@ -2,8 +2,16 @@
 {% block title %}تنظیمات دستگاه{% endblock %}
 {% block management_content %}
 <h1>دستگاه ثبت تردد</h1>
-<p>وضعیت اتصال: {{ device.online|yesno:"آنلاین,آفلاین" }}</p>
-<p>وضعیت فعالیت: {{ device.is_active|yesno:"فعال,غیرفعال" }}</p>
+<p>وضعیت اتصال:
+  <span class="badge {% if device.online %}badge-success{% else %}badge-error{% endif %}">
+    {{ device.online|yesno:"آنلاین,آفلاین" }}
+  </span>
+</p>
+<p>وضعیت فعالیت:
+  <span class="badge {% if device.is_active %}badge-success{% else %}badge-error{% endif %}">
+    {{ device.is_active|yesno:"فعال,غیرفعال" }}
+  </span>
+</p>
 <form method="post">
   {% csrf_token %}
   {% if device.online %}

--- a/templates/core/edit_requests.html
+++ b/templates/core/edit_requests.html
@@ -6,6 +6,9 @@
   <i class="fas fa-edit"></i>
   درخواست‌های ویرایش
 </h2>
+<div class="profile-actions" style="margin-bottom:1rem;">
+  <a class="btn" href="{% url 'manual_log' %}"><i class="fas fa-keyboard" style="margin-left:0.4rem;"></i> ثبت دستی تردد</a>
+</div>
 <form method="get" class="form-inline" style="margin-bottom:1rem;">
   <select name="group">
     <option value="">همه گروه‌ها</option>

--- a/templates/core/manual_log_form.html
+++ b/templates/core/manual_log_form.html
@@ -1,0 +1,22 @@
+{% extends "core/base_management.html" %}
+{% block title %}ثبت دستی تردد{% endblock %}
+{% block management_content %}
+<h2 class="page-title"><i class="fas fa-keyboard"></i> ثبت دستی تردد</h2>
+<form method="post">
+  {% csrf_token %}
+  <div class="form-group">
+    {{ form.user.label_tag }}<br>
+    {{ form.user }}
+  </div>
+  <div class="form-group">
+    {{ form.timestamp.label_tag }}<br>
+    {{ form.timestamp }}
+  </div>
+  <div class="form-group">
+    {{ form.log_type.label_tag }}<br>
+    {{ form.log_type }}
+  </div>
+  <button type="submit" class="btn"><i class="fas fa-check" style="margin-left:0.4rem;"></i> ثبت</button>
+  <a class="btn" href="{% url 'edit_requests' %}"><i class="fas fa-chevron-right" style="margin-left:0.4rem;"></i> بازگشت</a>
+</form>
+{% endblock %}

--- a/templates/core/my_edit_requests.html
+++ b/templates/core/my_edit_requests.html
@@ -11,30 +11,6 @@
     کد پرسنلی: {{ user.personnel_code }}
   </div>
   {% if requests %}
-  <div class="request-cards">
-    {% for r in requests %}
-    <div class="request-card fade-in">
-      <div class="row"><span class="label">زمان:</span><span>{{ r.timestamp|jformat:"%Y/%m/%d %H:%M" }}</span></div>
-      <div class="row"><span class="label">نوع:</span><span>{% if r.log_type == 'in' %}ورود{% else %}خروج{% endif %}</span></div>
-      <div class="row"><span class="label">توضیح:</span><span>{{ r.note|default:"-" }}</span></div>
-      <div class="row"><span class="label">وضعیت:</span>
-        <span class="badge {% if r.status == 'approved' %}badge-success{% elif r.status == 'rejected' %}badge-error{% elif r.status == 'cancelled' %}badge-warning{% else %}badge-info{% endif %}">
-          {% if r.status == 'pending' %}در انتظار{% elif r.status == 'approved' %}تأیید شده{% elif r.status == 'cancelled' %}لغو شده{% else %}رد شده{% endif %}
-        </span>
-      </div>
-      <div class="row"><span class="label">توضیح مدیر:</span><span>{{ r.manager_note|default:"-" }}</span></div>
-      <div class="actions">
-        {% if r.status == 'pending' %}
-        <form method="post" action="{% url 'cancel_edit_request' r.id %}" style="display:flex;gap:0.4rem;">
-          {% csrf_token %}
-          <button class="btn btn-danger" style="font-size:0.8rem;">لغو</button>
-        </form>
-        {% endif %}
-      </div>
-    </div>
-    {% endfor %}
-  </div>
-
   <div class="table-responsive">
   <table class="management-table">
     <thead>


### PR DESCRIPTION
## Summary
- color-code device status text
- allow managers to register manual attendance logs
- use date pickers and responsive tables on user log pages

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68923d48b5b48333ac7edbe4556d0ef4