### PR TITLE
feat: verify random movement in face registration

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -6,6 +6,8 @@ from datetime import timedelta, datetime, time
 
 import face_recognition
 import numpy as np
+import cv2
+import os
 from PIL import Image
 from django.contrib import messages
 from django.contrib.auth import get_user_model, login, logout
@@ -87,6 +89,84 @@ def _get_face_encoding_from_base64(data_url: str):
     except Exception as e:
         print("Face encode error:", e)
         return None
+
+
+def _verify_action(frames, action):
+    """Check requested random action in given frames using simple landmarks heuristics."""
+    metrics = []
+    for frame in frames:
+        landmarks = face_recognition.face_landmarks(frame)
+        if not landmarks:
+            continue
+        lm = landmarks[0]
+        if action == "blink":
+            left = np.array(lm["left_eye"])
+            right = np.array(lm["right_eye"])
+            def ear(eye):
+                A = np.linalg.norm(eye[1] - eye[5])
+                B = np.linalg.norm(eye[2] - eye[4])
+                C = np.linalg.norm(eye[0] - eye[3])
+                return (A + B) / (2.0 * C)
+            metrics.append((ear(left) + ear(right)) / 2.0)
+        elif action == "smile":
+            top = np.mean(lm["top_lip"], axis=0)
+            bottom = np.mean(lm["bottom_lip"], axis=0)
+            metrics.append(abs(top[1] - bottom[1]))
+        elif action == "turn_head":
+            nose = np.mean(lm["nose_tip"], axis=0)
+            metrics.append(nose[0])
+    if not metrics:
+        return False
+    if action == "blink":
+        return min(metrics) < 0.18
+    if action == "smile":
+        return max(metrics) - min(metrics) > 5
+    if action == "turn_head":
+        return max(metrics) - min(metrics) > 15
+    return False
+
+
+def _process_video_action(data_url, action):
+    """Extract encoding and raw image bytes from a video data URL if action verified."""
+    tmp_path = None
+    try:
+        if not data_url or "," not in data_url:
+            return None, None
+        _, b64data = data_url.split(",", 1)
+        video_bytes = base64.b64decode(b64data)
+
+        faces_dir = os.path.join(settings.MEDIA_ROOT, "faces")
+        os.makedirs(faces_dir, exist_ok=True)
+        tmp_path = os.path.join(faces_dir, f"tmp_{secrets.token_hex(8)}.webm")
+        with open(tmp_path, "wb") as f:
+            f.write(video_bytes)
+
+        cap = cv2.VideoCapture(tmp_path)
+        frames = []
+        while True:
+            ret, frame = cap.read()
+            if not ret:
+                break
+            frames.append(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB))
+        cap.release()
+    except Exception as e:
+        print("Video decode error:", e)
+        frames = []
+    finally:
+        if tmp_path and os.path.exists(tmp_path):
+            try:
+                os.remove(tmp_path)
+            except OSError:
+                pass
+    if not frames or not _verify_action(frames, action):
+        return None, None
+    encs = face_recognition.face_encodings(frames[0], num_jitters=3, model="large")
+    if not encs:
+        return None, None
+    img = Image.fromarray(frames[0])
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG")
+    return encs[0], buf.getvalue()
 
 
 # —————————————————————————
@@ -237,36 +317,18 @@ def api_verify_face(request):
 @require_POST
 @login_required
 def api_register_face(request):
-    """ثبت چهرهٔ کاربر با بررسی حرکت ساده برای جلوگیری از تقلب."""
-    img1 = request.POST.get("image1")
-    img2 = request.POST.get("image2")
-    if img1 and img2:
-        enc1 = _get_face_encoding_from_base64(img1)
-        enc2 = _get_face_encoding_from_base64(img2)
-        if enc1 is None or enc2 is None:
-            return JsonResponse({"ok": False, "msg": "چهره واضح نیست."})
-        # تفاوت دو تصویر باید از حدی بیشتر باشد تا اطمینان پیدا کنیم عکس ثابت نیست
-        movement = np.linalg.norm(enc1 - enc2)
-        if movement < 0.08:
-            return JsonResponse({"ok": False, "msg": "حرکت تشخیص داده نشد."})
-        enc = (enc1 + enc2) / 2
-        data_url = img1
-    else:
-        # حالت قدیمی، بدون لایونس
-        data_url = request.POST.get("image", "")
-        enc = _get_face_encoding_from_base64(data_url)
-        if enc is None:
-            return JsonResponse({"ok": False, "msg": "چهره‌ای شناسایی نشد."})
+    """ثبت چهرهٔ کاربر با دریافت ویدئو و بررسی حرکت تصادفی."""
+    action = request.POST.get("action", "")
+    video_data = request.POST.get("video", "")
+    enc, img_bytes = _process_video_action(video_data, action)
+    if enc is None or img_bytes is None:
+        return JsonResponse({"ok": False, "msg": "حرکت یا چهره تشخیص داده نشد."})
 
     request.user.face_encoding = enc.tobytes()
 
-    # ذخیرهٔ تصویر خام
     try:
-        header, b64data = data_url.split(",", 1)
-        fmt = header.split(";")[0].split("/")[1]
-        img_data = base64.b64decode(b64data)
-        filename = f"{request.user.username}_face.{fmt}"
-        request.user.face_image.save(filename, ContentFile(img_data), save=False)
+        filename = f"{request.user.username}_face.jpeg"
+        request.user.face_image.save(filename, ContentFile(img_bytes), save=False)
     except Exception:
         pass
 

--- a/templates/core/register_face.html
+++ b/templates/core/register_face.html
@@ -5,63 +5,66 @@
 <script>
 document.addEventListener('DOMContentLoaded', () => {
   const video = document.getElementById('video');
-  const canvas = document.getElementById('canvas');
   const btn = document.getElementById('captureBtn');
   const message = document.getElementById('captureResult');
+  let stream = null;
 
-  const steps = [
-    'اکنون مستقیم نگاه کنید و دکمه را بزنید.',
-    'حالا سرتان را کمی به چپ یا راست بچرخانید و دوباره بزنید.'
-  ];
-  let captures = [];
-  let step = 0;
-  message.textContent = steps[0];
+  const actions = {
+    'turn_head': 'لطفاً سرتان را به چپ و راست بچرخانید و سپس دکمه را بزنید.',
+    'smile': 'لطفاً لبخند بزنید و سپس دکمه را بزنید.',
+    'blink': 'چندبار پلک بزنید و سپس دکمه را بزنید.'
+  };
+  const keys = Object.keys(actions);
+  const currentAction = keys[Math.floor(Math.random() * keys.length)];
+  message.textContent = actions[currentAction];
 
   if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
     navigator.mediaDevices.getUserMedia({ video: { facingMode: "user" } })
-      .then(stream => { video.srcObject = stream; })
+      .then(s => { stream = s; video.srcObject = s; })
       .catch(() => { message.textContent = "دسترسی به دوربین ممکن نشد."; });
   } else {
     message.textContent = "دوربین توسط مرورگر پشتیبانی نمی‌شود.";
   }
 
   btn.onclick = () => {
-    if (video.readyState !== video.HAVE_ENOUGH_DATA) return;
-    canvas.width = video.videoWidth;
-    canvas.height = video.videoHeight;
-    canvas.getContext('2d').drawImage(video, 0, 0, canvas.width, canvas.height);
-    captures.push(canvas.toDataURL('image/jpeg'));
-    step++;
-    if (step < steps.length) {
-      message.textContent = steps[step];
-      return;
-    }
+    if (!stream) return;
+    message.textContent = 'در حال ضبط...';
     btn.disabled = true;
-    message.textContent = 'در حال ثبت...';
-    fetch("{% url 'api_register_face' %}", {
-      method: 'POST',
-      headers: { 'X-CSRFToken': getCsrfToken() },
-      body: new URLSearchParams({ image1: captures[0], image2: captures[1] })
-    })
-    .then(r => r.json())
-    .then(data => {
-      if (data.ok) {
-        message.textContent = 'چهره با موفقیت ثبت شد.';
-        if (data.redirect) {
-          setTimeout(() => { window.location.href = data.redirect; }, 1200);
-        }
-      } else {
-        message.textContent = data.msg || 'ثبت چهره ناموفق بود.';
-        btn.disabled = false;
-        step = 0;
-        captures = [];
-      }
-    }).catch(() => {
-      message.textContent = 'ارتباط با سرور برقرار نشد.';
-      btn.disabled = false;
-      step = 0;
-      captures = [];
-    });
+    const recorder = new MediaRecorder(stream, { mimeType: 'video/webm' });
+    let chunks = [];
+    recorder.ondataavailable = e => chunks.push(e.data);
+    recorder.onstop = () => {
+      const blob = new Blob(chunks, { type: 'video/webm' });
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        const form = new FormData();
+        form.append('action', currentAction);
+        form.append('video', reader.result);
+        fetch("{% url 'api_register_face' %}", {
+          method: 'POST',
+          headers: { 'X-CSRFToken': getCsrfToken() },
+          body: form
+        })
+        .then(r => r.json())
+        .then(data => {
+          if (data.ok) {
+            message.textContent = 'چهره با موفقیت ثبت شد.';
+            if (data.redirect) {
+              setTimeout(() => { window.location.href = data.redirect; }, 1200);
+            }
+          } else {
+            message.textContent = data.msg || 'ثبت چهره ناموفق بود.';
+            btn.disabled = false;
+          }
+        }).catch(() => {
+          message.textContent = 'ارتباط با سرور برقرار نشد.';
+          btn.disabled = false;
+        });
+      };
+      reader.readAsDataURL(blob);
+    };
+    recorder.start();
+    setTimeout(() => recorder.stop(), 3000);
   };
 
   function getCsrfToken() {
@@ -76,8 +79,7 @@ document.addEventListener('DOMContentLoaded', () => {
 {% block content %}
 <div class="fullscreen-container">
   <video id="video" autoplay muted playsinline></video>
-  <canvas id="canvas" style="display:none"></canvas>
-  <button class="action-btn" id="captureBtn"><i class="fa fa-camera" style="margin-left:0.4rem;"></i> ثبت تصویر</button>
+  <button class="action-btn" id="captureBtn"><i class="fa fa-video" style="margin-left:0.4rem;"></i> ضبط ویدئو</button>
   <div id="captureResult" class="status-bar"></div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- capture short video instead of still photos during face registration
- require random action (blink, smile, head turn) validated via OpenCV
- reject registration if requested movement is not detected
- store temp registration videos under `MEDIA_ROOT/faces` so OpenCV can read them on Windows

## Testing
- `apt-get install -y libgl1`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68930eecaffc83339e976b71f7dd5832