### PR TITLE
Remove CSV export endpoints

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -17,7 +17,6 @@ urlpatterns = [
     path('management/edit-requests/add-log/', views.add_log, name='add_log'),
     path('management/leave-requests/', views.leave_requests, name='leave_requests'),
     path('management/leave-requests/add/', views.add_leave, name='add_leave'),
-    path('management/logs/export/', views.export_logs_csv, name='export_logs_csv'),
     path('management/attendance-status/', views.attendance_status, name='attendance_status'),
     path('management/attendance-status/api/', views.api_attendance_status, name='api_attendance_status'),
 
@@ -35,7 +34,6 @@ urlpatterns = [
     path("user/inquiry/",           views.user_inquiry,                   name="user_inquiry"),
     path("user/profile/",           views.user_profile,                  name="user_profile"),
     path("user/logs/",              views.my_logs,                        name="my_logs"),
-    path("user/logs/export/",      views.export_my_logs_csv,             name="export_my_logs_csv"),
     path("user/edit-request/",     views.edit_request,                  name="edit_request"),
     path("user/leave-request/",    views.leave_request,                 name="leave_request"),
     path("user/edit-request/<int:pk>/cancel/",  views.cancel_edit_request,  name="cancel_edit_request"),

--- a/templates/attendance/my_logs.html
+++ b/templates/attendance/my_logs.html
@@ -36,7 +36,6 @@
     </table>
   </div>
   <div class="profile-actions">
-    <a class="btn" href="{% url 'export_my_logs_csv' %}" style="margin-left:0.5rem;"><i class="fa fa-download" style="margin-left:0.4rem;"></i> دریافت CSV</a>
     <a class="btn" href="{% url 'edit_request' %}" style="margin-left:0.5rem;"><i class="fa fa-edit" style="margin-left:0.4rem;"></i> درخواست ویرایش</a>
     <a class="btn" href="{% url 'user_edit_requests' %}" style="margin-left:0.5rem;"><i class="fa fa-list" style="margin-left:0.4rem;"></i> درخواست‌های ویرایش</a>
     <a class="btn" href="{% url 'user_profile' %}"><i class="fas fa-chevron-right" style="margin-left:0.4rem;"></i> بازگشت</a>

--- a/templates/core/user_reports.html
+++ b/templates/core/user_reports.html
@@ -23,9 +23,6 @@
   <canvas id="statusChart" height="160"></canvas>
   <canvas id="faceChart" height="160"></canvas>
 </div>
-<a class="btn" href="{% url 'export_logs_csv' %}" style="margin:1rem 0;display:inline-block;">
-  <i class="fa fa-download" style="margin-left:0.4rem;"></i> دانلود گزارش CSV
-</a>
 <div class="request-cards mobile-only">
   {% for log in latest_logs %}
   <div class="request-card fade-in">


### PR DESCRIPTION
## Summary
- drop deprecated export views and URL routes
- clean up templates by removing CSV export buttons

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68937c9fb4b4833387367def415c1355