### PR TITLE
Fix form titles and button spacing

### DIFF
--- a/static/core/global.css
+++ b/static/core/global.css
@@ -156,6 +156,7 @@ input[type="submit"], .btn {
     text-decoration: none;
     text-align: center;
     direction: rtl;
+    display: inline-block;
 }
 
 .btn-danger {

--- a/static/core/global.css
+++ b/static/core/global.css
@@ -413,6 +413,8 @@ label {
 .form-grid .form-group { margin-bottom: 0; }
 @media (min-width: 600px) {
   .form-grid { grid-template-columns: repeat(2, 1fr); }
+  /* keep small cards single-column to avoid overflowing backgrounds */
+  .page-sm.form-grid { grid-template-columns: 1fr; }
 }
 
 /* card layout for personal logs */

--- a/templates/core/group_form.html
+++ b/templates/core/group_form.html
@@ -1,12 +1,20 @@
 {% extends "core/base_management.html" %}
-{% if form.instance.pk %}{% block title %}ویرایش گروه{% endblock %}{% else %}{% block title %}افزودن گروه{% endblock %}{% endif %}
+{% block title %}{% if form.instance.pk %}ویرایش گروه{% else %}افزودن گروه{% endif %}{% endblock %}
 {% block management_content %}
 <h2 class="page-title">
   {% if form.instance.pk %}<i class="fas fa-edit"></i> ویرایش گروه{% else %}<i class="fas fa-plus"></i> افزودن گروه{% endif %}
 </h2>
 <form method="post" class="card page page-sm form-grid" autocomplete="off">
-  {{ form.as_p }}
-  <div class="profile-actions">
+  {% for field in form %}
+    <div class="form-group">
+      {{ field.label_tag }}
+      {{ field }}
+      {% for error in field.errors %}
+        <div class="error">{{ error }}</div>
+      {% endfor %}
+    </div>
+  {% endfor %}
+  <div class="profile-actions" style="grid-column:1/-1;">
     <button type="submit" class="btn">{% if form.instance.pk %}ذخیره{% else %}افزودن{% endif %}</button>
     <a href="{% url 'group_list' %}" class="btn" style="background:var(--color-muted);color:#fff;">لغو</a>
   </div>

--- a/templates/core/leave_type_form.html
+++ b/templates/core/leave_type_form.html
@@ -1,12 +1,20 @@
 {% extends "core/base_management.html" %}
-{% if form.instance.pk %}{% block title %}ویرایش نوع مرخصی{% endblock %}{% else %}{% block title %}افزودن نوع مرخصی{% endblock %}{% endif %}
+{% block title %}{% if form.instance.pk %}ویرایش نوع مرخصی{% else %}افزودن نوع مرخصی{% endif %}{% endblock %}
 {% block management_content %}
 <h2 class="page-title">
   {% if form.instance.pk %}<i class="fas fa-edit"></i> ویرایش نوع مرخصی{% else %}<i class="fas fa-plus"></i> افزودن نوع مرخصی{% endif %}
 </h2>
 <form method="post" class="card page page-sm form-grid" autocomplete="off">
-  {{ form.as_p }}
-  <div class="profile-actions">
+  {% for field in form %}
+    <div class="form-group">
+      {{ field.label_tag }}
+      {{ field }}
+      {% for error in field.errors %}
+        <div class="error">{{ error }}</div>
+      {% endfor %}
+    </div>
+  {% endfor %}
+  <div class="profile-actions" style="grid-column:1/-1;">
     <button type="submit" class="btn">{% if form.instance.pk %}ذخیره{% else %}افزودن{% endif %}</button>
     <a href="{% url 'leave_type_list' %}" class="btn" style="background:var(--color-muted);color:#fff;">لغو</a>
   </div>

--- a/templates/core/shift_form.html
+++ b/templates/core/shift_form.html
@@ -1,12 +1,20 @@
 {% extends "core/base_management.html" %}
-{% if form.instance.pk %}{% block title %}ویرایش شیفت{% endblock %}{% else %}{% block title %}افزودن شیفت{% endblock %}{% endif %}
+{% block title %}{% if form.instance.pk %}ویرایش شیفت{% else %}افزودن شیفت{% endif %}{% endblock %}
 {% block management_content %}
 <h2 class="page-title">
   {% if form.instance.pk %}<i class="fas fa-edit"></i> ویرایش شیفت{% else %}<i class="fas fa-plus"></i> افزودن شیفت{% endif %}
 </h2>
 <form method="post" class="card page page-sm form-grid" autocomplete="off">
-  {{ form.as_p }}
-  <div class="profile-actions">
+  {% for field in form %}
+    <div class="form-group">
+      {{ field.label_tag }}
+      {{ field }}
+      {% for error in field.errors %}
+        <div class="error">{{ error }}</div>
+      {% endfor %}
+    </div>
+  {% endfor %}
+  <div class="profile-actions" style="grid-column:1/-1;">
     <button type="submit" class="btn">{% if form.instance.pk %}ذخیره{% else %}افزودن{% endif %}</button>
     <a href="{% url 'shift_list' %}" class="btn" style="background:var(--color-muted);color:#fff;">لغو</a>
   </div>

--- a/templates/core/user_form.html
+++ b/templates/core/user_form.html
@@ -24,7 +24,7 @@
       {% endfor %}
     </div>
   {% endfor %}
-  <div class="profile-actions">
+  <div class="profile-actions" style="grid-column:1/-1;">
     <button type="submit" class="btn">
       {% if form.instance.pk %}ذخیره تغییرات{% else %}ایجاد کاربر{% endif %}
     </button>


### PR DESCRIPTION
## Summary
- ensure action buttons respect spacing by making `.btn` display inline-block
- render management forms (group, leave type, shift) with conditional titles and consistent form-group layout
- span profile action sections across full form width for better background coverage

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68945ae09dfc8333875faec046d4769f