### PR TITLE
Restore CSRF protections removed in PR #61

### DIFF
--- a/attendance_project/settings.py
+++ b/attendance_project/settings.py
@@ -27,6 +27,7 @@ MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',

--- a/core/views.py
+++ b/core/views.py
@@ -19,6 +19,7 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.templatetags.static import static
 from django.urls import reverse
 from django.utils import timezone
+from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 
 from attendance.models import (
@@ -164,6 +165,7 @@ def api_device_verify_face(request):
     except Exception:
         return JsonResponse({"success": False, "error": "خطا در پردازش تصویر."})
 
+@csrf_exempt
 @require_POST
 @login_required
 def api_verify_face(request):
@@ -448,6 +450,7 @@ def management_face_check(request):
     return render(request, "core/management_face_check.html")
 
 
+@csrf_exempt
 @login_required
 @staff_required
 def api_management_verify_face(request):

--- a/static/core/device.js
+++ b/static/core/device.js
@@ -38,7 +38,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const dataUrl = canvas.toDataURL('image/jpeg');
       fetch(VERIFY_FACE_URL, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", "X-CSRFToken": getCsrfToken() },
         body: JSON.stringify({ image: dataUrl })
       })
       .then(r => r.json())
@@ -72,5 +72,11 @@ document.addEventListener('DOMContentLoaded', () => {
       overlay.style.opacity = '0';
       setTimeout(() => overlay.style.display = 'none', 500); // با توجه به duration transition در CSS (اینجا 2 ثانیه)
     }, 2000); // بعد از ۳.۵ ثانیه محو میشه
+  }
+  function getCsrfToken() {
+    let value = "; " + document.cookie;
+    let parts = value.split("; csrftoken=");
+    if (parts.length === 2) return parts.pop().split(";").shift();
+    return '';
   }
 });

--- a/templates/core/confirm_delete.html
+++ b/templates/core/confirm_delete.html
@@ -5,6 +5,7 @@
 <div class="card">
   <p>آیا از حذف <b>{{ object }}</b> مطمئن هستید؟</p>
   <form method="post">
+    {% csrf_token %}
     <button type="submit" class="btn alert-error">حذف</button>
     <a href="{% url cancel_url %}" class="btn" style="background:var(--color-muted);color:#fff;">لغو</a>
   </form>

--- a/templates/core/device_face_check.html
+++ b/templates/core/device_face_check.html
@@ -33,7 +33,7 @@ document.addEventListener('DOMContentLoaded', () => {
     message.textContent = 'لطفاً صبر کنید...';
     fetch("{% url 'api_device_verify_face' %}", {
       method: 'POST',
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", "X-CSRFToken": getCsrfToken() },
       body: JSON.stringify({ image: dataUrl })
     })
     .then(r => r.json())
@@ -51,6 +51,12 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   };
 
+  function getCsrfToken() {
+    let value = "; " + document.cookie;
+    let parts = value.split("; csrftoken=");
+    if (parts.length === 2) return parts.pop().split(";").shift();
+    return '';
+  }
 });
 </script>
 {% endblock %}

--- a/templates/core/device_login.html
+++ b/templates/core/device_login.html
@@ -11,6 +11,7 @@
     ورود دستگاه تردد
   </h2>
   <form method="post" autocomplete="off">
+    {% csrf_token %}
     {% if form.non_field_errors %}
       <div class="error">{{ form.non_field_errors.0 }}</div>
     {% endif %}

--- a/templates/core/device_settings.html
+++ b/templates/core/device_settings.html
@@ -15,6 +15,7 @@
   </span>
 </p>
 <form method="post">
+  {% csrf_token %}
   {% if device.online %}
     {% if device.is_active %}
       <button type="submit" name="action" value="deactivate" class="btn">غیرفعال کردن</button>

--- a/templates/core/edit_request_form.html
+++ b/templates/core/edit_request_form.html
@@ -4,6 +4,7 @@
 <div class="card page page-md">
   <h2 class="page-title">درخواست ویرایش تردد برای {{ user.get_full_name }}</h2>
   <form method="post">
+    {% csrf_token %}
     <div class="form-group">
       {{ form.date.label_tag }}<br>
       {{ form.date }}

--- a/templates/core/edit_requests.html
+++ b/templates/core/edit_requests.html
@@ -37,6 +37,7 @@
     <div class="actions">
       {% if r.status == 'pending' %}
       <form method="post" class="actions" style="flex:1;">
+        {% csrf_token %}
         <input type="hidden" name="req_id" value="{{ r.id }}">
         <input type="text" name="manager_note" placeholder="توضیح" style="flex:1;min-width:80px;">
         <button name="action" value="approve" class="btn" style="font-size:0.9rem;">تأیید</button>
@@ -78,6 +79,7 @@
       <td>
         {% if r.status == 'pending' %}
         <form method="post" style="display:flex;gap:0.3rem;flex-wrap:wrap;">
+          {% csrf_token %}
           <input type="hidden" name="req_id" value="{{ r.id }}">
           <input type="text" name="manager_note" placeholder="توضیح" style="flex:1;min-width:80px;">
           <button name="action" value="approve" class="btn" style="font-size:0.9rem;">تأیید</button>

--- a/templates/core/group_form.html
+++ b/templates/core/group_form.html
@@ -5,6 +5,7 @@
   {% if form.instance.pk %}<i class="fas fa-edit"></i> ویرایش گروه{% else %}<i class="fas fa-plus"></i> افزودن گروه{% endif %}
 </h2>
 <form method="post" class="card page page-sm form-grid" autocomplete="off">
+  {% csrf_token %}
   {% for field in form %}
     <div class="form-group">
       {{ field.label_tag }}

--- a/templates/core/leave_request_confirm.html
+++ b/templates/core/leave_request_confirm.html
@@ -10,6 +10,7 @@
   <p>نوع مرخصی: {{ form.cleaned_data.leave_type }}</p>
   {% endif %}
   <form method="post">
+    {% csrf_token %}
     {% for f in form.hidden_fields %}{{ f }}{% endfor %}
     <input type="hidden" name="confirm" value="1">
     <button class="btn" type="submit">ثبت</button>

--- a/templates/core/leave_request_form.html
+++ b/templates/core/leave_request_form.html
@@ -4,6 +4,7 @@
 <div class="card page page-md">
   <h2 class="page-title">درخواست مرخصی برای {{ user.get_full_name }}</h2>
   <form method="post">
+    {% csrf_token %}
     <div class="form-group">
       {{ form.leave_type.label_tag }}<br>
       {{ form.leave_type }}

--- a/templates/core/leave_requests.html
+++ b/templates/core/leave_requests.html
@@ -40,6 +40,7 @@
     <div class="actions">
       {% if r.status == 'pending' %}
       <form method="post" class="actions" style="flex:1;">
+        {% csrf_token %}
         <input type="hidden" name="req_id" value="{{ r.id }}">
         <input type="text" name="manager_note" placeholder="توضیح" style="flex:1;min-width:80px;">
         <button name="action" value="approve" class="btn" style="font-size:0.9rem;">تأیید</button>
@@ -48,6 +49,7 @@
       </form>
       {% elif r.start_date > today %}
       <form method="post" class="actions" style="flex:1;">
+        {% csrf_token %}
         <input type="hidden" name="req_id" value="{{ r.id }}">
         <select name="status">
           <option value="pending" {% if r.status == 'pending' %}selected{% endif %}>در انتظار</option>
@@ -95,6 +97,7 @@
       <td>
         {% if r.status == 'pending' %}
         <form method="post" style="display:flex;gap:0.3rem;flex-wrap:wrap;">
+          {% csrf_token %}
           <input type="hidden" name="req_id" value="{{ r.id }}">
           <input type="text" name="manager_note" placeholder="توضیح" style="flex:1;min-width:80px;">
           <button name="action" value="approve" class="btn" style="font-size:0.9rem;">تأیید</button>
@@ -103,6 +106,7 @@
         </form>
         {% elif r.start_date > today %}
         <form method="post" style="display:flex;gap:0.3rem;flex-wrap:wrap;">
+          {% csrf_token %}
           <input type="hidden" name="req_id" value="{{ r.id }}">
           <select name="status">
             <option value="pending" {% if r.status == 'pending' %}selected{% endif %}>در انتظار</option>

--- a/templates/core/leave_type_form.html
+++ b/templates/core/leave_type_form.html
@@ -5,6 +5,7 @@
   {% if form.instance.pk %}<i class="fas fa-edit"></i> ویرایش نوع مرخصی{% else %}<i class="fas fa-plus"></i> افزودن نوع مرخصی{% endif %}
 </h2>
 <form method="post" class="card page page-sm form-grid" autocomplete="off">
+  {% csrf_token %}
   {% for field in form %}
     <div class="form-group">
       {{ field.label_tag }}

--- a/templates/core/management_face_check.html
+++ b/templates/core/management_face_check.html
@@ -36,7 +36,8 @@ document.addEventListener('DOMContentLoaded', () => {
       const res = await fetch('{% url "api_management_verify_face" %}', {
         method: 'POST',
         headers: {
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
+          'X-CSRFToken': getCsrf()
         },
         body: JSON.stringify({ image: dataUrl })
       });
@@ -54,6 +55,12 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   };
 
+  function getCsrf() {
+    return document.cookie.split(';')
+      .map(c => c.trim())
+      .find(c => c.startsWith('csrftoken='))
+      ?.split('=')[1] || '';
+  }
 });
 </script>
 {% endblock %}

--- a/templates/core/management_login.html
+++ b/templates/core/management_login.html
@@ -11,6 +11,7 @@
     ورود مدیریت
   </h2>
   <form method="post" autocomplete="off">
+    {% csrf_token %}
     {% if form.non_field_errors %}
       <div class="error">{{ form.non_field_errors.0 }}</div>
     {% endif %}

--- a/templates/core/manual_leave_form.html
+++ b/templates/core/manual_leave_form.html
@@ -9,6 +9,7 @@
   <i class="fas fa-chevron-right" style="margin-left:0.4rem;"></i> بازگشت
 </a>
 <form method="post" class="card" autocomplete="off">
+  {% csrf_token %}
   {% for field in form %}
     <div class="form-group">
       {{ field.label_tag }}

--- a/templates/core/manual_log_form.html
+++ b/templates/core/manual_log_form.html
@@ -3,6 +3,7 @@
 {% block management_content %}
 <h2 class="page-title"><i class="fas fa-plus"></i> ثبت دستی تردد</h2>
 <form method="post">
+  {% csrf_token %}
   <div class="form-group">
     {{ form.user.label_tag }}<br>{{ form.user }}
   </div>

--- a/templates/core/my_edit_requests.html
+++ b/templates/core/my_edit_requests.html
@@ -26,6 +26,7 @@
       <div class="actions">
         {% if r.status == 'pending' %}
         <form method="post" action="{% url 'cancel_edit_request' r.id %}" style="display:flex;gap:0.4rem;">
+          {% csrf_token %}
           <button class="btn btn-danger" style="font-size:0.8rem;">لغو</button>
         </form>
         {% endif %}
@@ -61,6 +62,7 @@
         <td>
           {% if r.status == 'pending' %}
           <form method="post" action="{% url 'cancel_edit_request' r.id %}">
+            {% csrf_token %}
             <button class="btn btn-danger" style="font-size:0.8rem;">لغو</button>
           </form>
           {% else %}-{% endif %}

--- a/templates/core/my_leave_requests.html
+++ b/templates/core/my_leave_requests.html
@@ -25,6 +25,7 @@
       <div class="actions">
         {% if r.status == 'pending' %}
         <form method="post" action="{% url 'cancel_leave_request' r.id %}" style="display:flex;gap:0.4rem;">
+          {% csrf_token %}
           <button class="btn btn-danger" style="font-size:0.8rem;">لغو</button>
         </form>
         {% endif %}
@@ -60,6 +61,7 @@
         <td>
           {% if r.status == 'pending' %}
           <form method="post" action="{% url 'cancel_leave_request' r.id %}">
+            {% csrf_token %}
             <button class="btn btn-danger" style="font-size:0.8rem;">لغو</button>
           </form>
           {% else %}-{% endif %}

--- a/templates/core/register_face.html
+++ b/templates/core/register_face.html
@@ -40,6 +40,7 @@ document.addEventListener('DOMContentLoaded', () => {
     message.textContent = 'در حال ثبت...';
     fetch("{% url 'api_register_face' %}", {
       method: 'POST',
+      headers: { 'X-CSRFToken': getCsrfToken() },
       body: new URLSearchParams({ image1: captures[0], image2: captures[1] })
     })
     .then(r => r.json())
@@ -63,6 +64,12 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   };
 
+  function getCsrfToken() {
+    let value = "; " + document.cookie;
+    let parts = value.split("; csrftoken=");
+    if (parts.length === 2) return parts.pop().split(";").shift();
+    return '';
+  }
 });
 </script>
 {% endblock %}

--- a/templates/core/register_face_for_user.html
+++ b/templates/core/register_face_for_user.html
@@ -40,6 +40,7 @@ document.addEventListener('DOMContentLoaded', () => {
     message.textContent = 'در حال ثبت...';
     fetch("{% url 'register_face_api' user_to_register.pk %}", {
       method: 'POST',
+      headers: { 'X-CSRFToken': getCsrfToken() },
       body: new URLSearchParams({ image1: captures[0], image2: captures[1] })
     })
     .then(r => r.json())
@@ -60,6 +61,12 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   };
 
+  function getCsrfToken() {
+    let value = "; " + document.cookie;
+    let parts = value.split("; csrftoken=");
+    if (parts.length === 2) return parts.pop().split(";").shift();
+    return '';
+  }
 });
 </script>
 {% endblock %}

--- a/templates/core/shift_form.html
+++ b/templates/core/shift_form.html
@@ -5,6 +5,7 @@
   {% if form.instance.pk %}<i class="fas fa-edit"></i> ویرایش شیفت{% else %}<i class="fas fa-plus"></i> افزودن شیفت{% endif %}
 </h2>
 <form method="post" class="card page page-sm form-grid" autocomplete="off">
+  {% csrf_token %}
   {% for field in form %}
     <div class="form-group">
       {{ field.label_tag }}

--- a/templates/core/user_confirm_delete.html
+++ b/templates/core/user_confirm_delete.html
@@ -11,6 +11,7 @@
     با کد پرسنلی <b>{{ user.personnel_code }}</b> را حذف کنید؟
   </p>
   <form method="post">
+    {% csrf_token %}
     <button type="submit" class="btn alert-error"><i class="fas fa-trash-alt" style="margin-left:0.4rem;"></i> بله، حذف شود</button>
     <a href="{% url 'management_users' %}" class="btn" style="background:var(--color-muted);color:#fff;">انصراف</a>
   </form>

--- a/templates/core/user_form.html
+++ b/templates/core/user_form.html
@@ -12,6 +12,7 @@
   <i class="fas fa-chevron-right" style="margin-left:0.4rem;"></i> بازگشت به لیست
 </a>
 <form method="post" enctype="multipart/form-data" class="card page page-sm form-grid" autocomplete="off">
+  {% csrf_token %}
   {% for field in form %}
     <div class="form-group">
       {{ field.label_tag }}

--- a/templates/core/user_inquiry.html
+++ b/templates/core/user_inquiry.html
@@ -6,6 +6,7 @@
     <i class="fas fa-search"></i> مشاهده تردد من
   </h2>
   <form method="post" autocomplete="off">
+    {% csrf_token %}
     {% if form.non_field_errors %}
       <div class="error">{{ form.non_field_errors.0 }}</div>
     {% endif %}

--- a/templates/core/verify_face.html
+++ b/templates/core/verify_face.html
@@ -24,7 +24,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const dataUrl = canvas.toDataURL('image/jpeg');
       fetch("{% url 'api_verify_face' %}", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", "X-CSRFToken": getCsrfToken() },
         body: JSON.stringify({ image: dataUrl })
       })
       .then(r => r.json())
@@ -40,6 +40,12 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }, 4000);
 
+  function getCsrfToken() {
+    let value = "; " + document.cookie;
+    let parts = value.split("; csrftoken=");
+    if (parts.length === 2) return parts.pop().split(";").shift();
+    return '';
+  }
 });
 </script>
 {% endblock %}

--- a/templates/core/weekly_holidays.html
+++ b/templates/core/weekly_holidays.html
@@ -3,6 +3,7 @@
 {% block management_content %}
 <h2 class="page-title"><i class="fas fa-calendar-day"></i> تنظیم روزهای تعطیل</h2>
 <form method="post" class="card page page-sm form-grid" style="margin-top:1rem;">
+  {% csrf_token %}
   <h3 class="panel-title" style="grid-column:1/-1;">{{ form.days.label }}</h3>
   {% for checkbox in form.days %}
     <label class="form-group">{{ checkbox.tag }} {{ checkbox.choice_label }}</label>


### PR DESCRIPTION
## Summary
- Revert the "Remove CSRF protection" changes
- Restore `CsrfViewMiddleware` and CSRF tokens across forms and face verification endpoints

## Testing
- `python manage.py test` *(failed: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_689523b489408333a852e07a915dae3b