### PR TITLE
Revamp management dashboard with interactive widgets

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -600,7 +600,12 @@ def management_dashboard(request):
     if shift_id:
         users_qs = users_qs.filter(shift_id=shift_id)
 
-    today_logs = AttendanceLog.objects.filter(user__in=users_qs, timestamp__date=today).count()
+    today_in_logs = AttendanceLog.objects.filter(
+        user__in=users_qs, timestamp__date=today, log_type="in"
+    ).count()
+    today_out_logs = AttendanceLog.objects.filter(
+        user__in=users_qs, timestamp__date=today, log_type="out"
+    ).count()
 
     # لیست کارکنان حاضر، غایب و مرخصی
     if is_holiday:
@@ -719,7 +724,8 @@ def management_dashboard(request):
 
     context = {
         'active_tab': 'dashboard',
-        'today_logs': today_logs,
+        'today_in_logs': today_in_logs,
+        'today_out_logs': today_out_logs,
         'present_users': present_users,
         'absent_users': absent_users,
         'leave_users': leave_users,

--- a/core/views.py
+++ b/core/views.py
@@ -600,9 +600,7 @@ def management_dashboard(request):
     if shift_id:
         users_qs = users_qs.filter(shift_id=shift_id)
 
-    total_users = users_qs.count()
     today_logs = AttendanceLog.objects.filter(user__in=users_qs, timestamp__date=today).count()
-    users_without_face = users_qs.filter(face_encoding__isnull=True).count()
 
     # لیست کارکنان حاضر، غایب و مرخصی
     if is_holiday:
@@ -628,66 +626,82 @@ def management_dashboard(request):
         absent_users = users_qs.exclude(id__in=present_ids).exclude(id__in=leave_ids)
 
     tardy_users = User.objects.none()
-    total_hours = 0
     if not is_holiday:
         tardy_ids = []
-        total_seconds = 0
         present_users_details = users_qs.filter(id__in=present_ids).select_related("shift", "group__shift")
         for user in present_users_details:
             shift = _get_user_shift(user)
             shift_start = time(9, 0)
-            shift_end = time(17, 0)
             if shift:
                 shift_start = shift.start_time
-                shift_end = shift.end_time
             first_log = AttendanceLog.objects.filter(user=user, timestamp__date=today).order_by("timestamp").first()
-            last_log = AttendanceLog.objects.filter(user=user, timestamp__date=today).order_by("timestamp").last()
             if first_log:
-                if shift:
-                    start_dt, end_dt = _shift_bounds(today, shift)
-                else:
-                    start_dt = datetime.combine(today, shift_start)
-                    end_dt = datetime.combine(today, shift_end)
+                start_dt = datetime.combine(today, shift_start)
                 first_dt = first_log.timestamp
                 if first_dt.tzinfo is not None:
                     first_dt = first_dt.replace(tzinfo=None)
                 if first_dt > start_dt:
                     tardy_ids.append(user.id)
-                if last_log and last_log != first_log:
-                    last_dt = last_log.timestamp
-                    if last_dt.tzinfo is not None:
-                        last_dt = last_dt.replace(tzinfo=None)
-                    if last_dt < first_dt:
-                        last_dt = first_dt
-                    work_start = max(first_dt, start_dt)
-                    work_end = min(last_dt, end_dt)
-                    if work_end > work_start:
-                        total_seconds += (work_end - work_start).total_seconds()
         tardy_users = users_qs.filter(id__in=tardy_ids)
-        total_hours = round(total_seconds / 3600, 2)
 
     # هشدارها
-    pending_edits = EditRequest.objects.filter(user__in=users_qs, status="pending").count()
-    pending_leaves = LeaveRequest.objects.filter(user__in=users_qs, status="pending").count()
+    pending_edit_objs = EditRequest.objects.select_related("user").filter(user__in=users_qs, status="pending")
+    pending_leave_objs = LeaveRequest.objects.select_related("user").filter(user__in=users_qs, status="pending")
+    pending_edits = pending_edit_objs.count()
+    pending_leaves = pending_leave_objs.count()
     suspicious_today = SuspiciousLog.objects.filter(matched_user__in=users_qs, timestamp__date=today).count()
 
-    # نمودار تردد 7 روز اخیر
-    date_range = [today - timedelta(days=i) for i in range(6, -1, -1)]
-    daily_logs = []
-    for date in date_range:
-        logs = AttendanceLog.objects.filter(user__in=users_qs, timestamp__date=date).count()
-        daily_logs.append(logs)
+    # مرکز اقدامات فوری: ترکیب درخواست‌های مرخصی و ویرایش
+    pending_actions = []
+    for req in pending_edit_objs[:5]:
+        pending_actions.append({
+            "id": req.id,
+            "user": req.user,
+            "date": req.timestamp.date(),
+            "type": "edit",
+            "type_label": "ویرایش تردد",
+            "action_url": reverse("edit_requests"),
+        })
+    for req in pending_leave_objs[:5]:
+        pending_actions.append({
+            "id": req.id,
+            "user": req.user,
+            "date": req.start_date,
+            "type": "leave",
+            "type_label": "مرخصی",
+            "action_url": reverse("leave_requests"),
+        })
 
-    # prepare JSON for chart rendering
-    import json
-    labels_json = json.dumps([d.strftime('%Y-%m-%d') for d in date_range])
-    logs_json = json.dumps(daily_logs)
+    # رادار عملکرد: محاسبه دیرکرد در یک ماه اخیر
+    month_start = today - timedelta(days=30)
+    perf_stats = []
+    for u in users_qs:
+        tardies = 0
+        shift = _get_user_shift(u)
+        shift_start = shift.start_time if shift else time(9, 0)
+        for i in range(31):
+            day = month_start + timedelta(days=i)
+            first_log = (
+                AttendanceLog.objects.filter(user=u, timestamp__date=day)
+                .order_by("timestamp")
+                .first()
+            )
+            if first_log:
+                log_time = first_log.timestamp
+                if log_time.tzinfo is not None:
+                    log_time = log_time.replace(tzinfo=None)
+                if log_time.time() > shift_start:
+                    tardies += 1
+        perf_stats.append((u, tardies))
+    worst_performers = sorted(perf_stats, key=lambda x: x[1], reverse=True)[:5]
+    best_performers = sorted(perf_stats, key=lambda x: x[1])[:5]
+
+    device = Device.objects.first()
+    device_online = device.online if device else False
 
     context = {
         'active_tab': 'dashboard',
-        'total_users': total_users,
         'today_logs': today_logs,
-        'users_without_face': users_without_face,
         'present_users': present_users,
         'absent_users': absent_users,
         'leave_users': leave_users,
@@ -698,9 +712,10 @@ def management_dashboard(request):
         'pending_edits': pending_edits,
         'pending_leaves': pending_leaves,
         'suspicious_today': suspicious_today,
-        'total_hours': total_hours,
-        'date_range_json': labels_json,
-        'daily_logs_json': logs_json,
+        'pending_actions': pending_actions,
+        'worst_performers': worst_performers,
+        'best_performers': best_performers,
+        'device_online': device_online,
         'is_holiday': is_holiday,
         'groups': Group.objects.all(),
         'shifts': Shift.objects.all(),
@@ -853,6 +868,9 @@ def edit_requests(request):
                 req.manager_note = note
                 req.save()
                 messages.info(request, "درخواست لغو شد.")
+        next_url = request.POST.get("next")
+        if next_url:
+            return redirect(next_url)
         return redirect("edit_requests")
     group_id = request.GET.get("group")
     shift_id = request.GET.get("shift")
@@ -908,6 +926,9 @@ def leave_requests(request):
                 req.manager_note = note
                 req.save()
                 messages.success(request, "وضعیت مرخصی به‌روزرسانی شد.")
+        next_url = request.POST.get("next")
+        if next_url:
+            return redirect(next_url)
         return redirect("leave_requests")
     group_id = request.GET.get("group")
     shift_id = request.GET.get("shift")

--- a/core/views.py
+++ b/core/views.py
@@ -657,7 +657,7 @@ def management_dashboard(request):
         pending_actions.append({
             "id": req.id,
             "user": req.user,
-            "date": req.timestamp.date(),
+            "date": jdatetime.date.fromgregorian(date=req.timestamp.date()).strftime("%Y/%m/%d"),
             "type": "edit",
             "type_label": "ویرایش تردد",
             "action_url": reverse("edit_requests"),
@@ -666,7 +666,7 @@ def management_dashboard(request):
         pending_actions.append({
             "id": req.id,
             "user": req.user,
-            "date": req.start_date,
+            "date": jdatetime.date.fromgregorian(date=req.start_date).strftime("%Y/%m/%d"),
             "type": "leave",
             "type_label": "مرخصی",
             "action_url": reverse("leave_requests"),

--- a/core/views.py
+++ b/core/views.py
@@ -656,7 +656,7 @@ def management_dashboard(request):
     pending_leaves = pending_leave_objs.count()
     suspicious_today = SuspiciousLog.objects.filter(matched_user__in=users_qs, timestamp__date=today).count()
 
-    # مرکز اقدامات فوری: ترکیب درخواست‌های مرخصی و ویرایش
+    # اقدامات فوری: ترکیب درخواست‌های مرخصی و ویرایش
     pending_actions = []
     for req in pending_edit_objs[:5]:
         pending_actions.append({

--- a/static/core/management.css
+++ b/static/core/management.css
@@ -401,6 +401,33 @@
   margin-top: 0.6rem;
 }
 
+.action-btn {
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  padding: 0.3rem 0.8rem;
+  font-size: 0.85rem;
+  color: var(--color-primary-dark);
+  cursor: pointer;
+  transition: background var(--transition), color var(--transition);
+}
+
+.action-btn:hover {
+  background: var(--color-primary);
+  color: #fff;
+}
+
+.action-btn.reject {
+  background: var(--color-error);
+  color: #fff;
+  border: none;
+}
+
+.action-btn.reject:hover {
+  background: #b71c1c;
+}
+
 /* small-screen adjustments */
 @media (max-width: 900px) {
   .table-responsive, .management-table { display: none; }

--- a/static/core/management.css
+++ b/static/core/management.css
@@ -225,6 +225,14 @@
 }
 .alerts-list li:last-child { border-bottom: none; }
 
+.kiosk-status {
+  font-size: 0.9rem;
+  margin-right: 1rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
 .status-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
@@ -251,6 +259,33 @@
   overflow-y: auto;
 }
 
+.status-lists {
+  margin-top: 1rem;
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+.status-list {
+  background: var(--color-bg);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  border: 1px solid var(--color-border);
+  padding: 0.8rem;
+  flex: 1 1 200px;
+}
+.status-list h4 {
+  margin-bottom: 0.5rem;
+  color: var(--color-primary-dark);
+  font-size: 1.05rem;
+}
+.status-list ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: 220px;
+  overflow-y: auto;
+}
+
 .panel-title {
   margin-bottom: 1rem;
   font-size: 1.2rem;
@@ -258,6 +293,24 @@
   display: flex;
   align-items: center;
   gap: 0.4rem;
+}
+
+.performance-grid {
+  display: flex;
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+.performance-grid > div {
+  flex: 1 1 200px;
+}
+.performance-grid ol {
+  padding-left: 1rem;
+  margin: 0;
+}
+
+.btn-small {
+  padding: 0.2rem 0.6rem;
+  font-size: 0.85rem;
 }
 
 /* responsive cards used for leave/edit requests */

--- a/static/core/management.css
+++ b/static/core/management.css
@@ -134,6 +134,13 @@
 .status-offline { color: #f44336; }
 .status-active { color: #4caf50; }
 .status-inactive { color: #f44336; }
+.status-overview {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  margin-bottom: 2rem;
+}
 .dashboard-stats {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
@@ -322,9 +329,27 @@
   font-size: 1.05rem;
 }
 
-.performance-box ol {
-  padding-left: 1rem;
-  margin: 0;
+.performance-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.performance-table th,
+.performance-table td {
+  padding: 0.4rem 0.6rem;
+  border-bottom: 1px solid var(--color-border);
+  text-align: right;
+  font-size: 0.9rem;
+}
+
+.performance-table th {
+  background: var(--color-bg);
+  color: var(--color-primary);
+  font-weight: 600;
+}
+
+.performance-table tbody tr:last-child td {
+  border-bottom: none;
 }
 
 .btn-small {

--- a/static/core/management.css
+++ b/static/core/management.css
@@ -286,6 +286,12 @@
   overflow-y: auto;
 }
 
+.status-chart {
+  max-width: 220px;
+  max-height: 220px;
+  margin: 0 auto;
+}
+
 .panel-title {
   margin-bottom: 1rem;
   font-size: 1.2rem;
@@ -295,15 +301,28 @@
   gap: 0.4rem;
 }
 
-.performance-grid {
+.performance-wrapper {
   display: flex;
-  gap: 2rem;
+  gap: 1rem;
   flex-wrap: wrap;
 }
-.performance-grid > div {
+
+.performance-box {
+  background: var(--color-bg);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  border: 1px solid var(--color-border);
+  padding: 0.8rem;
   flex: 1 1 200px;
 }
-.performance-grid ol {
+
+.performance-box h4 {
+  margin-bottom: 0.5rem;
+  color: var(--color-primary-dark);
+  font-size: 1.05rem;
+}
+
+.performance-box ol {
   padding-left: 1rem;
   margin: 0;
 }

--- a/static/core/management.css
+++ b/static/core/management.css
@@ -149,7 +149,7 @@
 }
 @media (min-width: 1000px) {
   .dashboard-stats {
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(2, 1fr);
   }
 }
 .dashboard-card {
@@ -327,6 +327,26 @@
   margin-bottom: 0.5rem;
   color: var(--color-primary-dark);
   font-size: 1.05rem;
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.info-icon {
+  cursor: pointer;
+  color: var(--color-primary);
+  font-size: 0.85rem;
+}
+
+.info-text {
+  display: none;
+  font-size: 0.85rem;
+  color: var(--color-muted);
+  margin-bottom: 0.5rem;
+}
+
+.info-text.visible {
+  display: block;
 }
 
 .performance-table {

--- a/templates/core/management_dashboard.html
+++ b/templates/core/management_dashboard.html
@@ -24,16 +24,22 @@
   <button class="btn" type="submit">فیلتر</button>
 </form>
 
-<div class="status-overview">
-  <div class="card fade-in">
-    <h3 class="panel-title"><i class="fas fa-heartbeat"></i> وضعیت مجموعه</h3>
-    <canvas id="statusChart" width="220" height="220" class="status-chart"></canvas>
+<div class="dashboard-stats">
+  <div class="dashboard-card">
+    <i class="fas fa-sign-in-alt"></i>
+    <span class="value">{{ today_in_logs }}</span>
+    <span class="label">ورود امروز</span>
   </div>
   <div class="dashboard-card">
-    <i class="fas fa-clock"></i>
-    <span class="value">{{ today_logs }}</span>
-    <span class="label">تردد امروز</span>
+    <i class="fas fa-sign-out-alt"></i>
+    <span class="value">{{ today_out_logs }}</span>
+    <span class="label">خروج امروز</span>
   </div>
+</div>
+
+<div class="card fade-in">
+  <h3 class="panel-title"><i class="fas fa-heartbeat"></i> وضعیت مجموعه</h3>
+  <canvas id="statusChart" width="220" height="220" class="status-chart"></canvas>
 </div>
 
 <div class="status-lists">
@@ -57,6 +63,27 @@
       {% endfor %}
     </ul>
   </div>
+  </div>
+
+<div class="card fade-in">
+  <h3 class="panel-title"><i class="fas fa-bell"></i> هشدارها</h3>
+  <ul class="alerts-list">
+    {% for u in tardy_users %}
+      <li>{{ u.get_full_name }} - {{ u.personnel_code }} دیرکرد در ورود</li>
+    {% endfor %}
+    {% if pending_edits %}
+      <li>{{ pending_edits }} درخواست ویرایش تردد در انتظار</li>
+    {% endif %}
+    {% if pending_leaves %}
+      <li>{{ pending_leaves }} درخواست مرخصی در انتظار</li>
+    {% endif %}
+    {% if suspicious_today %}
+      <li>{{ suspicious_today }} مورد عدم تطابق چهره</li>
+    {% endif %}
+    {% if not tardy_users and not pending_edits and not pending_leaves and not suspicious_today %}
+      <li>هشداری وجود ندارد.</li>
+    {% endif %}
+  </ul>
 </div>
 
 <div class="card fade-in">
@@ -127,26 +154,6 @@
   </div>
 </div>
 
-<div class="card fade-in">
-  <h3 class="panel-title"><i class="fas fa-bell"></i> هشدارها</h3>
-  <ul class="alerts-list">
-    {% for u in tardy_users %}
-      <li>{{ u.get_full_name }} - {{ u.personnel_code }} دیرکرد در ورود</li>
-    {% endfor %}
-    {% if pending_edits %}
-      <li>{{ pending_edits }} درخواست ویرایش تردد در انتظار</li>
-    {% endif %}
-    {% if pending_leaves %}
-      <li>{{ pending_leaves }} درخواست مرخصی در انتظار</li>
-    {% endif %}
-    {% if suspicious_today %}
-      <li>{{ suspicious_today }} مورد عدم تطابق چهره</li>
-    {% endif %}
-    {% if not tardy_users and not pending_edits and not pending_leaves and not suspicious_today %}
-      <li>هشداری وجود ندارد.</li>
-    {% endif %}
-  </ul>
-</div>
 {% endblock %}
 
 {% block extra_js %}

--- a/templates/core/management_dashboard.html
+++ b/templates/core/management_dashboard.html
@@ -87,7 +87,7 @@
 </div>
 
 <div class="card fade-in">
-  <h3 class="panel-title"><i class="fas fa-bolt"></i> مرکز اقدامات فوری</h3>
+  <h3 class="panel-title"><i class="fas fa-bolt"></i> اقدامات فوری</h3>
   <div class="request-cards mobile-only">
     {% for r in pending_actions %}
     <div class="request-card fade-in">
@@ -100,14 +100,14 @@
           <input type="hidden" name="req_id" value="{{ r.id }}">
           <input type="hidden" name="action" value="approve">
           <input type="hidden" name="next" value="management_dashboard">
-          <button class="btn btn-small" type="submit">تأیید</button>
+          <button class="action-btn" type="submit">تأیید</button>
         </form>
         <form method="post" action="{{ r.action_url }}" style="display:inline-block;">
           {% csrf_token %}
           <input type="hidden" name="req_id" value="{{ r.id }}">
           <input type="hidden" name="action" value="reject">
           <input type="hidden" name="next" value="management_dashboard">
-          <button class="btn btn-small" type="submit" style="background:var(--color-muted);color:#fff;">رد</button>
+          <button class="action-btn reject" type="submit">رد</button>
         </form>
       </div>
     </div>
@@ -132,14 +132,14 @@
               <input type="hidden" name="req_id" value="{{ r.id }}">
               <input type="hidden" name="action" value="approve">
               <input type="hidden" name="next" value="management_dashboard">
-              <button class="btn btn-small" type="submit">تأیید</button>
+              <button class="action-btn" type="submit">تأیید</button>
             </form>
             <form method="post" action="{{ r.action_url }}" style="display:inline-block;">
               {% csrf_token %}
               <input type="hidden" name="req_id" value="{{ r.id }}">
               <input type="hidden" name="action" value="reject">
               <input type="hidden" name="next" value="management_dashboard">
-              <button class="btn btn-small" type="submit" style="background:var(--color-muted);color:#fff;">رد</button>
+              <button class="action-btn reject" type="submit">رد</button>
             </form>
           </td>
         </tr>

--- a/templates/core/management_dashboard.html
+++ b/templates/core/management_dashboard.html
@@ -88,45 +88,75 @@
 
 <div class="card fade-in">
   <h3 class="panel-title"><i class="fas fa-bolt"></i> مرکز اقدامات فوری</h3>
-  <table class="management-table">
-    <thead>
-      <tr><th>کاربر</th><th>تاریخ</th><th>نوع</th><th>اقدام</th></tr>
-    </thead>
-    <tbody>
-      {% for r in pending_actions %}
-      <tr>
-        <td>{{ r.user.get_full_name }}</td>
-        <td>{{ r.date }}</td>
-        <td>{{ r.type_label }}</td>
-        <td>
-          <form method="post" action="{{ r.action_url }}" style="display:inline-block;">
-            {% csrf_token %}
-            <input type="hidden" name="req_id" value="{{ r.id }}">
-            <input type="hidden" name="action" value="approve">
-            <input type="hidden" name="next" value="management_dashboard">
-            <button class="btn btn-small" type="submit">تأیید</button>
-          </form>
-          <form method="post" action="{{ r.action_url }}" style="display:inline-block;">
-            {% csrf_token %}
-            <input type="hidden" name="req_id" value="{{ r.id }}">
-            <input type="hidden" name="action" value="reject">
-            <input type="hidden" name="next" value="management_dashboard">
-            <button class="btn btn-small" type="submit" style="background:var(--color-muted);color:#fff;">رد</button>
-          </form>
-        </td>
-      </tr>
-      {% empty %}
-      <tr><td colspan="4">درخواستی وجود ندارد.</td></tr>
-      {% endfor %}
-    </tbody>
-  </table>
+  <div class="request-cards mobile-only">
+    {% for r in pending_actions %}
+    <div class="request-card fade-in">
+      <div class="row"><span class="label">کاربر:</span><span>{{ r.user.get_full_name }}</span></div>
+      <div class="row"><span class="label">تاریخ:</span><span>{{ r.date }}</span></div>
+      <div class="row"><span class="label">نوع:</span><span>{{ r.type_label }}</span></div>
+      <div class="actions">
+        <form method="post" action="{{ r.action_url }}" style="display:inline-block;">
+          {% csrf_token %}
+          <input type="hidden" name="req_id" value="{{ r.id }}">
+          <input type="hidden" name="action" value="approve">
+          <input type="hidden" name="next" value="management_dashboard">
+          <button class="btn btn-small" type="submit">تأیید</button>
+        </form>
+        <form method="post" action="{{ r.action_url }}" style="display:inline-block;">
+          {% csrf_token %}
+          <input type="hidden" name="req_id" value="{{ r.id }}">
+          <input type="hidden" name="action" value="reject">
+          <input type="hidden" name="next" value="management_dashboard">
+          <button class="btn btn-small" type="submit" style="background:var(--color-muted);color:#fff;">رد</button>
+        </form>
+      </div>
+    </div>
+    {% empty %}
+    <div class="alert-error">درخواستی وجود ندارد.</div>
+    {% endfor %}
+  </div>
+  <div class="table-responsive desktop-only">
+    <table class="management-table">
+      <thead>
+        <tr><th>کاربر</th><th>تاریخ</th><th>نوع</th><th>اقدام</th></tr>
+      </thead>
+      <tbody>
+        {% for r in pending_actions %}
+        <tr>
+          <td>{{ r.user.get_full_name }}</td>
+          <td>{{ r.date }}</td>
+          <td>{{ r.type_label }}</td>
+          <td>
+            <form method="post" action="{{ r.action_url }}" style="display:inline-block;">
+              {% csrf_token %}
+              <input type="hidden" name="req_id" value="{{ r.id }}">
+              <input type="hidden" name="action" value="approve">
+              <input type="hidden" name="next" value="management_dashboard">
+              <button class="btn btn-small" type="submit">تأیید</button>
+            </form>
+            <form method="post" action="{{ r.action_url }}" style="display:inline-block;">
+              {% csrf_token %}
+              <input type="hidden" name="req_id" value="{{ r.id }}">
+              <input type="hidden" name="action" value="reject">
+              <input type="hidden" name="next" value="management_dashboard">
+              <button class="btn btn-small" type="submit" style="background:var(--color-muted);color:#fff;">رد</button>
+            </form>
+          </td>
+        </tr>
+        {% empty %}
+        <tr><td colspan="4">درخواستی وجود ندارد.</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
 </div>
 
 <div class="card fade-in">
   <h3 class="panel-title"><i class="fas fa-users"></i> خوب‌ها و بدها</h3>
   <div class="performance-wrapper">
     <div class="performance-box">
-      <h4 title="کاربرانی با بیشترین روزهای دیرکرد در ماه اخیر">بدها</h4>
+      <h4>بدها <span class="info-icon" data-target="bad-info"><i class="fas fa-info-circle"></i></span></h4>
+      <div id="bad-info" class="info-text">کاربرانی با بیشترین روزهای دیرکرد در ماه اخیر</div>
       <table class="performance-table">
         <thead><tr><th>نام</th><th>تعداد</th></tr></thead>
         <tbody>
@@ -139,7 +169,8 @@
       </table>
     </div>
     <div class="performance-box">
-      <h4 title="کاربرانی با بیشترین روز بدون تأخیر متوالی">خوب‌ها</h4>
+      <h4>خوب‌ها <span class="info-icon" data-target="good-info"><i class="fas fa-info-circle"></i></span></h4>
+      <div id="good-info" class="info-text">کاربرانی با بیشترین روز بدون تأخیر متوالی</div>
       <table class="performance-table">
         <thead><tr><th>نام</th><th>تعداد</th></tr></thead>
         <tbody>
@@ -182,6 +213,15 @@ const statusChart = new Chart(statusCtx, {
       }
     }
   }
+});
+
+document.querySelectorAll('.info-icon').forEach(icon => {
+  icon.addEventListener('click', () => {
+    const target = document.getElementById(icon.dataset.target);
+    if (target) {
+      target.classList.toggle('visible');
+    }
+  });
 });
 </script>
 {% endblock %}

--- a/templates/core/management_dashboard.html
+++ b/templates/core/management_dashboard.html
@@ -24,17 +24,16 @@
   <button class="btn" type="submit">فیلتر</button>
 </form>
 
-<div class="dashboard-stats">
+<div class="status-overview">
+  <div class="card fade-in">
+    <h3 class="panel-title"><i class="fas fa-heartbeat"></i> وضعیت مجموعه</h3>
+    <canvas id="statusChart" width="220" height="220" class="status-chart"></canvas>
+  </div>
   <div class="dashboard-card">
     <i class="fas fa-clock"></i>
     <span class="value">{{ today_logs }}</span>
     <span class="label">تردد امروز</span>
   </div>
-</div>
-
-<div class="card fade-in">
-  <h3 class="panel-title"><i class="fas fa-heartbeat"></i> وضعیت مجموعه</h3>
-  <canvas id="statusChart" width="220" height="220" class="status-chart"></canvas>
 </div>
 
 <div class="status-lists">
@@ -100,24 +99,30 @@
   <h3 class="panel-title"><i class="fas fa-users"></i> خوب‌ها و بدها</h3>
   <div class="performance-wrapper">
     <div class="performance-box">
-      <h4>بدها</h4>
-      <ol>
+      <h4 title="کاربرانی با بیشترین روزهای دیرکرد در ماه اخیر">بدها</h4>
+      <table class="performance-table">
+        <thead><tr><th>نام</th><th>تعداد</th></tr></thead>
+        <tbody>
         {% for u, count in worst_performers %}
-          <li>{{ u.get_full_name }} - {{ count }} روز دیرکرد</li>
+          <tr><td>{{ u.get_full_name }}</td><td>{{ count }}</td></tr>
         {% empty %}
-          <li>موردی نیست</li>
+          <tr><td colspan="2">موردی نیست</td></tr>
         {% endfor %}
-      </ol>
+        </tbody>
+      </table>
     </div>
     <div class="performance-box">
-      <h4>خوب‌ها</h4>
-      <ol>
+      <h4 title="کاربرانی با بیشترین روز بدون تأخیر متوالی">خوب‌ها</h4>
+      <table class="performance-table">
+        <thead><tr><th>نام</th><th>تعداد</th></tr></thead>
+        <tbody>
         {% for u, count in best_performers %}
-          <li>{{ u.get_full_name }} - {{ count }} روز بدون تأخیر متوالی</li>
+          <tr><td>{{ u.get_full_name }}</td><td>{{ count }}</td></tr>
         {% empty %}
-          <li>موردی نیست</li>
+          <tr><td colspan="2">موردی نیست</td></tr>
         {% endfor %}
-      </ol>
+        </tbody>
+      </table>
     </div>
   </div>
 </div>

--- a/templates/core/management_dashboard.html
+++ b/templates/core/management_dashboard.html
@@ -33,21 +33,11 @@
 </div>
 
 <div class="card fade-in">
-  <h3 class="panel-title"><i class="fas fa-heartbeat"></i> نبض سازمان</h3>
-  <canvas id="pulseChart" height="160"></canvas>
+  <h3 class="panel-title"><i class="fas fa-heartbeat"></i> وضعیت مجموعه</h3>
+  <canvas id="statusChart" width="220" height="220" class="status-chart"></canvas>
 </div>
 
 <div class="status-lists">
-  <div id="presentList" class="status-list">
-    <h4>حاضرین امروز</h4>
-    <ul>
-      {% for u in present_users %}
-        <li>{{ u.get_full_name }} - {{ u.personnel_code }}</li>
-      {% empty %}
-        <li>موردی ثبت نشده است</li>
-      {% endfor %}
-    </ul>
-  </div>
   <div id="absentList" class="status-list" style="display:none;">
     <h4>غایبین امروز</h4>
     <ul>
@@ -107,10 +97,10 @@
 </div>
 
 <div class="card fade-in">
-  <h3 class="panel-title"><i class="fas fa-users"></i> رادار عملکرد</h3>
-  <div class="performance-grid">
-    <div>
-      <h4>متخلفان</h4>
+  <h3 class="panel-title"><i class="fas fa-users"></i> خوب‌ها و بدها</h3>
+  <div class="performance-wrapper">
+    <div class="performance-box">
+      <h4>بدها</h4>
       <ol>
         {% for u, count in worst_performers %}
           <li>{{ u.get_full_name }} - {{ count }} روز دیرکرد</li>
@@ -119,11 +109,11 @@
         {% endfor %}
       </ol>
     </div>
-    <div>
-      <h4>قهرمانان</h4>
+    <div class="performance-box">
+      <h4>خوب‌ها</h4>
       <ol>
         {% for u, count in best_performers %}
-          <li>{{ u.get_full_name }} - {{ count }} روز دیرکرد</li>
+          <li>{{ u.get_full_name }} - {{ count }} روز بدون تأخیر متوالی</li>
         {% empty %}
           <li>موردی نیست</li>
         {% endfor %}
@@ -157,8 +147,8 @@
 {% block extra_js %}
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script>
-const pulseCtx = document.getElementById('pulseChart').getContext('2d');
-const pulseChart = new Chart(pulseCtx, {
+const statusCtx = document.getElementById('statusChart').getContext('2d');
+const statusChart = new Chart(statusCtx, {
   type: 'doughnut',
   data: {
     labels: ['حاضر', 'غایب', 'مرخصی'],
@@ -172,8 +162,11 @@ const pulseChart = new Chart(pulseCtx, {
       if (els.length) {
         const idx = els[0].index;
         document.querySelectorAll('.status-list').forEach(el => el.style.display='none');
-        ['presentList','absentList','leaveList'][idx] &&
-          (document.getElementById(['presentList','absentList','leaveList'][idx]).style.display='block');
+        const targets = [null, 'absentList', 'leaveList'];
+        const target = targets[idx];
+        if (target) {
+          document.getElementById(target).style.display = 'block';
+        }
       }
     }
   }

--- a/templates/core/management_dashboard.html
+++ b/templates/core/management_dashboard.html
@@ -3,6 +3,10 @@
 {% block management_content %}
 <h2 class="page-title">
   <i class="fas fa-chart-bar"></i> داشبورد مدیریت
+  <span class="kiosk-status">
+    <i class="fas fa-circle {% if device_online %}status-online{% else %}status-offline{% endif %}"></i>
+    دستگاه {% if device_online %}آنلاین{% else %}آفلاین{% endif %}
+  </span>
 </h2>
 <form method="get" class="form-inline" style="margin-bottom:1rem;">
   <select name="group">
@@ -20,43 +24,110 @@
   <button class="btn" type="submit">فیلتر</button>
 </form>
 
-<div class="card dashboard-panel fade-in">
-  <h3 class="panel-title"><i class="fas fa-chart-pie"></i> آمار کلی</h3>
-  <div class="dashboard-stats">
-    <div class="dashboard-card">
-      <i class="fas fa-users"></i>
-      <span class="value">{{ total_users }}</span>
-      <span class="label">کل کاربران</span>
+<div class="dashboard-stats">
+  <div class="dashboard-card">
+    <i class="fas fa-clock"></i>
+    <span class="value">{{ today_logs }}</span>
+    <span class="label">تردد امروز</span>
+  </div>
+</div>
+
+<div class="card fade-in">
+  <h3 class="panel-title"><i class="fas fa-heartbeat"></i> نبض سازمان</h3>
+  <canvas id="pulseChart" height="160"></canvas>
+</div>
+
+<div class="status-lists">
+  <div id="presentList" class="status-list">
+    <h4>حاضرین امروز</h4>
+    <ul>
+      {% for u in present_users %}
+        <li>{{ u.get_full_name }} - {{ u.personnel_code }}</li>
+      {% empty %}
+        <li>موردی ثبت نشده است</li>
+      {% endfor %}
+    </ul>
+  </div>
+  <div id="absentList" class="status-list" style="display:none;">
+    <h4>غایبین امروز</h4>
+    <ul>
+      {% for u in absent_users %}
+        <li>{{ u.get_full_name }} - {{ u.personnel_code }}</li>
+      {% empty %}
+        <li>همه حاضرند</li>
+      {% endfor %}
+    </ul>
+  </div>
+  <div id="leaveList" class="status-list" style="display:none;">
+    <h4>در مرخصی</h4>
+    <ul>
+      {% for u in leave_users %}
+        <li>{{ u.get_full_name }} - {{ u.personnel_code }}</li>
+      {% empty %}
+        <li>موردی نیست</li>
+      {% endfor %}
+    </ul>
+  </div>
+</div>
+
+<div class="card fade-in">
+  <h3 class="panel-title"><i class="fas fa-bolt"></i> مرکز اقدامات فوری</h3>
+  <table class="management-table">
+    <thead>
+      <tr><th>کاربر</th><th>تاریخ</th><th>نوع</th><th>اقدام</th></tr>
+    </thead>
+    <tbody>
+      {% for r in pending_actions %}
+      <tr>
+        <td>{{ r.user.get_full_name }}</td>
+        <td>{{ r.date }}</td>
+        <td>{{ r.type_label }}</td>
+        <td>
+          <form method="post" action="{{ r.action_url }}" style="display:inline-block;">
+            {% csrf_token %}
+            <input type="hidden" name="req_id" value="{{ r.id }}">
+            <input type="hidden" name="action" value="approve">
+            <input type="hidden" name="next" value="management_dashboard">
+            <button class="btn btn-small" type="submit">تأیید</button>
+          </form>
+          <form method="post" action="{{ r.action_url }}" style="display:inline-block;">
+            {% csrf_token %}
+            <input type="hidden" name="req_id" value="{{ r.id }}">
+            <input type="hidden" name="action" value="reject">
+            <input type="hidden" name="next" value="management_dashboard">
+            <button class="btn btn-small" type="submit" style="background:var(--color-muted);color:#fff;">رد</button>
+          </form>
+        </td>
+      </tr>
+      {% empty %}
+      <tr><td colspan="4">درخواستی وجود ندارد.</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+
+<div class="card fade-in">
+  <h3 class="panel-title"><i class="fas fa-users"></i> رادار عملکرد</h3>
+  <div class="performance-grid">
+    <div>
+      <h4>متخلفان</h4>
+      <ol>
+        {% for u, count in worst_performers %}
+          <li>{{ u.get_full_name }} - {{ count }} روز دیرکرد</li>
+        {% empty %}
+          <li>موردی نیست</li>
+        {% endfor %}
+      </ol>
     </div>
-    <div class="dashboard-card">
-      <i class="fas fa-clock"></i>
-      <span class="value">{{ today_logs }}</span>
-      <span class="label">تردد امروز</span>
-    </div>
-    <div class="dashboard-card">
-      <i class="fas fa-user-slash"></i>
-      <span class="value">{{ users_without_face }}</span>
-      <span class="label">بدون ثبت چهره</span>
-    </div>
-    <div class="dashboard-card">
-      <i class="fas fa-user-check"></i>
-      <span class="value">{{ present_count }}</span>
-      <span class="label">حاضر امروز</span>
-    </div>
-    <div class="dashboard-card">
-      <i class="fas fa-user-times"></i>
-      <span class="value">{{ absent_count }}</span>
-      <span class="label">غایب امروز</span>
-    </div>
-    <div class="dashboard-card">
-      <i class="fas fa-plane"></i>
-      <span class="value">{{ leave_count }}</span>
-      <span class="label">در مرخصی</span>
-    </div>
-    <div class="dashboard-card">
-      <i class="fas fa-hourglass-half"></i>
-      <span class="value">{{ total_hours }}</span>
-      <span class="label">مجموع ساعات</span>
+    <div>
+      <h4>قهرمانان</h4>
+      <ol>
+        {% for u, count in best_performers %}
+          <li>{{ u.get_full_name }} - {{ count }} روز دیرکرد</li>
+        {% empty %}
+          <li>موردی نیست</li>
+        {% endfor %}
+      </ol>
     </div>
   </div>
 </div>
@@ -81,62 +152,31 @@
     {% endif %}
   </ul>
 </div>
-
-<div class="status-grid card fade-in">
-  <div class="status-card">
-    <h4>حاضرین امروز</h4>
-    <ul>
-      {% for u in present_users %}
-        <li>{{ u.get_full_name }} - {{ u.personnel_code }}</li>
-      {% empty %}
-        <li>موردی ثبت نشده است</li>
-      {% endfor %}
-    </ul>
-  </div>
-  <div class="status-card">
-    <h4>غایبین امروز</h4>
-    <ul>
-      {% for u in absent_users %}
-        <li>{{ u.get_full_name }} - {{ u.personnel_code }}</li>
-      {% empty %}
-        <li>همه حاضرند</li>
-      {% endfor %}
-    </ul>
-  </div>
-  <div class="status-card">
-    <h4>در مرخصی</h4>
-    <ul>
-      {% for u in leave_users %}
-        <li>{{ u.get_full_name }} - {{ u.personnel_code }}</li>
-      {% empty %}
-        <li>موردی نیست</li>
-      {% endfor %}
-    </ul>
-  </div>
-</div>
-
-<div class="card fade-in" style="margin-top:2rem;">
-  <canvas id="logsChart" height="120"></canvas>
-</div>
 {% endblock %}
 
 {% block extra_js %}
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script>
-const logLabels = {{ date_range_json|safe }};
-const logData = {{ daily_logs_json|safe }};
-new Chart(document.getElementById('logsChart').getContext('2d'), {
-  type: 'line',
+const pulseCtx = document.getElementById('pulseChart').getContext('2d');
+const pulseChart = new Chart(pulseCtx, {
+  type: 'doughnut',
   data: {
-    labels: logLabels,
+    labels: ['حاضر', 'غایب', 'مرخصی'],
     datasets: [{
-      label: 'تعداد تردد',
-      data: logData,
-      borderColor: '#3e95cd',
-      fill: false
+      data: [{{ present_count }}, {{ absent_count }}, {{ leave_count }}],
+      backgroundColor: ['#4caf50', '#f44336', '#ff9800']
     }]
   },
-  options: {scales: {y: {beginAtZero:true}}}
+  options: {
+    onClick: (evt, els) => {
+      if (els.length) {
+        const idx = els[0].index;
+        document.querySelectorAll('.status-list').forEach(el => el.style.display='none');
+        ['presentList','absentList','leaveList'][idx] &&
+          (document.getElementById(['presentList','absentList','leaveList'][idx]).style.display='block');
+      }
+    }
+  }
 });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Replace static dashboard cards with live donut chart and immediate action center
- Add performance radar and kiosk connectivity indicator
- Support direct approval workflow via dashboard with redirect handling

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68966de94c748333bee8fd8c65da21c9