### PR TITLE
Revamp management dashboard with interactive widgets

### DIFF
--- a/static/core/management.css
+++ b/static/core/management.css
@@ -130,6 +130,15 @@
   align-items: center;
   gap: 0.3rem;
 }
+.device-status {
+  margin-right: auto;
+  display: inline-flex;
+  align-items: center;
+  font-size: 1.1rem;
+}
+.device-status .online { color: #4caf50; }
+.device-status .offline { color: #f44336; animation: blink 1s step-start infinite; }
+@keyframes blink { 50% { opacity: 0; } }
 .status-online { color: #4caf50; }
 .status-offline { color: #f44336; }
 .status-active { color: #4caf50; }
@@ -283,6 +292,20 @@
   gap: 0.4rem;
   margin-top: 0.6rem;
 }
+
+.inline-form { display: inline-flex; gap: 0.4rem; }
+
+.performance-radar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+}
+.performance-radar ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.performance-radar .radar-column { flex: 1; min-width: 200px; }
 
 /* small-screen adjustments */
 @media (max-width: 900px) {

--- a/templates/core/management_dashboard.html
+++ b/templates/core/management_dashboard.html
@@ -3,6 +3,9 @@
 {% block management_content %}
 <h2 class="page-title">
   <i class="fas fa-chart-bar"></i> داشبورد مدیریت
+  <span class="device-status">
+    <i class="fas fa-hdd {% if device_online %}online{% else %}offline{% endif %}"></i>
+  </span>
 </h2>
 <form method="get" class="form-inline" style="margin-bottom:1rem;">
   <select name="group">
@@ -20,123 +23,93 @@
   <button class="btn" type="submit">فیلتر</button>
 </form>
 
-<div class="card dashboard-panel fade-in">
-  <h3 class="panel-title"><i class="fas fa-chart-pie"></i> آمار کلی</h3>
-  <div class="dashboard-stats">
-    <div class="dashboard-card">
-      <i class="fas fa-users"></i>
-      <span class="value">{{ total_users }}</span>
-      <span class="label">کل کاربران</span>
+<div class="card fade-in">
+  <h3 class="panel-title"><i class="fas fa-bolt"></i> مرکز اقدامات فوری</h3>
+  <table class="management-table">
+    <thead>
+      <tr><th>کاربر</th><th>تاریخ</th><th>نوع</th><th>اقدام</th></tr>
+    </thead>
+    <tbody>
+      {% for item in action_items %}
+      <tr>
+        <td>{{ item.obj.user.get_full_name }}</td>
+        <td>{% if item.type == 'leave' %}{{ item.obj.start_date }}{% else %}{{ item.obj.timestamp|date:'Y-m-d' }}{% endif %}</td>
+        <td>{% if item.type == 'leave' %}مرخصی{% else %}ویرایش تردد{% endif %}</td>
+        <td>
+          {% if item.type == 'leave' %}
+          {% url 'leave_requests' as action_url %}
+          {% else %}
+          {% url 'edit_requests' as action_url %}
+          {% endif %}
+          <form method="post" action="{{ action_url }}" class="inline-form">
+            {% csrf_token %}
+            <input type="hidden" name="req_id" value="{{ item.obj.id }}">
+            <button class="btn" name="action" value="approve">تأیید</button>
+            <button class="btn btn-secondary" name="action" value="reject">رد</button>
+          </form>
+        </td>
+      </tr>
+      {% empty %}
+      <tr><td colspan="4">درخواستی وجود ندارد.</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+
+<div class="card fade-in">
+  <h3 class="panel-title"><i class="fas fa-tachometer-alt"></i> رادار عملکرد</h3>
+  <div class="performance-radar">
+    <div class="radar-column">
+      <h4>بیشترین تأخیر</h4>
+      <ul>
+        {% for item in tardy_leaderboard %}
+          <li>{{ item.user.get_full_name }} - {{ item.count }} روز</li>
+        {% empty %}
+          <li>موردی نیست</li>
+        {% endfor %}
+      </ul>
     </div>
-    <div class="dashboard-card">
-      <i class="fas fa-clock"></i>
-      <span class="value">{{ today_logs }}</span>
-      <span class="label">تردد امروز</span>
-    </div>
-    <div class="dashboard-card">
-      <i class="fas fa-user-slash"></i>
-      <span class="value">{{ users_without_face }}</span>
-      <span class="label">بدون ثبت چهره</span>
-    </div>
-    <div class="dashboard-card">
-      <i class="fas fa-user-check"></i>
-      <span class="value">{{ present_count }}</span>
-      <span class="label">حاضر امروز</span>
-    </div>
-    <div class="dashboard-card">
-      <i class="fas fa-user-times"></i>
-      <span class="value">{{ absent_count }}</span>
-      <span class="label">غایب امروز</span>
-    </div>
-    <div class="dashboard-card">
-      <i class="fas fa-plane"></i>
-      <span class="value">{{ leave_count }}</span>
-      <span class="label">در مرخصی</span>
-    </div>
-    <div class="dashboard-card">
-      <i class="fas fa-hourglass-half"></i>
-      <span class="value">{{ total_hours }}</span>
-      <span class="label">مجموع ساعات</span>
+    <div class="radar-column">
+      <h4>منظم‌ترین‌ها</h4>
+      <ul>
+        {% for item in punctual_leaderboard %}
+          <li>{{ item.user.get_full_name }} - {{ item.count }} روز</li>
+        {% empty %}
+          <li>موردی نیست</li>
+        {% endfor %}
+      </ul>
     </div>
   </div>
 </div>
 
 <div class="card fade-in">
-  <h3 class="panel-title"><i class="fas fa-bell"></i> هشدارها</h3>
-  <ul class="alerts-list">
-    {% for u in tardy_users %}
-      <li>{{ u.get_full_name }} - {{ u.personnel_code }} دیرکرد در ورود</li>
-    {% endfor %}
-    {% if pending_edits %}
-      <li>{{ pending_edits }} درخواست ویرایش تردد در انتظار</li>
-    {% endif %}
-    {% if pending_leaves %}
-      <li>{{ pending_leaves }} درخواست مرخصی در انتظار</li>
-    {% endif %}
-    {% if suspicious_today %}
-      <li>{{ suspicious_today }} مورد عدم تطابق چهره</li>
-    {% endif %}
-    {% if not tardy_users and not pending_edits and not pending_leaves and not suspicious_today %}
-      <li>هشداری وجود ندارد.</li>
-    {% endif %}
-  </ul>
-</div>
-
-<div class="status-grid card fade-in">
-  <div class="status-card">
-    <h4>حاضرین امروز</h4>
-    <ul>
-      {% for u in present_users %}
-        <li>{{ u.get_full_name }} - {{ u.personnel_code }}</li>
-      {% empty %}
-        <li>موردی ثبت نشده است</li>
-      {% endfor %}
-    </ul>
-  </div>
-  <div class="status-card">
-    <h4>غایبین امروز</h4>
-    <ul>
-      {% for u in absent_users %}
-        <li>{{ u.get_full_name }} - {{ u.personnel_code }}</li>
-      {% empty %}
-        <li>همه حاضرند</li>
-      {% endfor %}
-    </ul>
-  </div>
-  <div class="status-card">
-    <h4>در مرخصی</h4>
-    <ul>
-      {% for u in leave_users %}
-        <li>{{ u.get_full_name }} - {{ u.personnel_code }}</li>
-      {% empty %}
-        <li>موردی نیست</li>
-      {% endfor %}
-    </ul>
-  </div>
-</div>
-
-<div class="card fade-in" style="margin-top:2rem;">
-  <canvas id="logsChart" height="120"></canvas>
+  <h3 class="panel-title"><i class="fas fa-chart-pie"></i> نبض سازمان</h3>
+  <canvas id="orgPulseChart" height="160"></canvas>
 </div>
 {% endblock %}
 
 {% block extra_js %}
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script>
-const logLabels = {{ date_range_json|safe }};
-const logData = {{ daily_logs_json|safe }};
-new Chart(document.getElementById('logsChart').getContext('2d'), {
-  type: 'line',
-  data: {
-    labels: logLabels,
-    datasets: [{
-      label: 'تعداد تردد',
-      data: logData,
-      borderColor: '#3e95cd',
-      fill: false
-    }]
-  },
-  options: {scales: {y: {beginAtZero:true}}}
+const orgData = {
+  labels: ['حاضر', 'غایب', 'مرخصی'],
+  datasets: [{
+    data: [{{ present_count }}, {{ absent_count }}, {{ leave_count }}],
+    backgroundColor: ['#4caf50', '#f44336', '#ffc107']
+  }]
+};
+const nameLists = [{{ present_names_json|safe }}, {{ absent_names_json|safe }}, {{ leave_names_json|safe }}];
+const orgChart = new Chart(document.getElementById('orgPulseChart'), {
+  type: 'doughnut',
+  data: orgData,
+  options: {
+    onClick: (evt, elements) => {
+      if (!elements.length) return;
+      const idx = elements[0].index;
+      const names = nameLists[idx];
+      alert(names.length ? names.join('\n') : 'موردی نیست');
+    }
+  }
 });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Replace static dashboard stats with actionable widgets
- Add performance radar and real-time organization pulse chart
- Show kiosk connectivity and inline approval for pending requests

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68966de94c748333bee8fd8c65da21c9