### PR TITLE
feat: add advanced user reports and monthly profile

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -315,14 +315,22 @@ class ReportFilterForm(forms.Form):
     start_date = jforms.jDateField(
         label="از تاریخ",
         widget=AdminjDateWidget(
-            attrs={"placeholder": "۱۴۰۳/۰۵/۱۰", "class": "date-input"}
+            attrs={
+                "placeholder": "۱۴۰۳/۰۵/۱۰",
+                "class": "date-input vjDateField",
+                "readonly": "readonly",
+            }
         ),
         required=False,
     )
     end_date = jforms.jDateField(
         label="تا تاریخ",
         widget=AdminjDateWidget(
-            attrs={"placeholder": "۱۴۰۳/۰۵/۱۰", "class": "date-input"}
+            attrs={
+                "placeholder": "۱۴۰۳/۰۵/۱۰",
+                "class": "date-input vjDateField",
+                "readonly": "readonly",
+            }
         ),
         required=False,
     )

--- a/core/forms.py
+++ b/core/forms.py
@@ -313,29 +313,43 @@ class LeaveTypeForm(forms.ModelForm):
 
 class ReportFilterForm(forms.Form):
     start_date = jforms.jDateField(
-        label="از تاریخ", widget=AdminjDateWidget(), required=False
+        label="از تاریخ",
+        widget=AdminjDateWidget(
+            attrs={"placeholder": "۱۴۰۳/۰۵/۱۰", "class": "date-input"}
+        ),
+        required=False,
     )
     end_date = jforms.jDateField(
-        label="تا تاریخ", widget=AdminjDateWidget(), required=False
+        label="تا تاریخ",
+        widget=AdminjDateWidget(
+            attrs={"placeholder": "۱۴۰۳/۰۵/۱۰", "class": "date-input"}
+        ),
+        required=False,
     )
     groups = forms.ModelMultipleChoiceField(
         queryset=Group.objects.all(),
         label="گروه‌ها",
         required=False,
-        widget=forms.CheckboxSelectMultiple,
+        widget=forms.SelectMultiple(attrs={"class": "multi-select"}),
     )
     shifts = forms.ModelMultipleChoiceField(
         queryset=Shift.objects.all(),
         label="شیفت‌ها",
         required=False,
-        widget=forms.CheckboxSelectMultiple,
+        widget=forms.SelectMultiple(attrs={"class": "multi-select"}),
     )
     users = forms.ModelMultipleChoiceField(
         queryset=User.objects.all(),
         label="کاربران",
         required=False,
-        widget=forms.CheckboxSelectMultiple,
+        widget=forms.SelectMultiple(attrs={"class": "multi-select"}),
     )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["users"].label_from_instance = (
+            lambda obj: f"{obj.personnel_code} – {obj.last_name}"
+        )
 
 
 class MonthlyPerformanceForm(forms.Form):

--- a/core/forms.py
+++ b/core/forms.py
@@ -319,16 +319,40 @@ class ReportFilterForm(forms.Form):
         label="تا تاریخ", widget=AdminjDateWidget(), required=False
     )
     groups = forms.ModelMultipleChoiceField(
-        queryset=Group.objects.all(), label="گروه‌ها", required=False
+        queryset=Group.objects.all(),
+        label="گروه‌ها",
+        required=False,
+        widget=forms.CheckboxSelectMultiple,
     )
     shifts = forms.ModelMultipleChoiceField(
-        queryset=Shift.objects.all(), label="شیفت‌ها", required=False
+        queryset=Shift.objects.all(),
+        label="شیفت‌ها",
+        required=False,
+        widget=forms.CheckboxSelectMultiple,
     )
     users = forms.ModelMultipleChoiceField(
-        queryset=User.objects.all(), label="کاربران", required=False
+        queryset=User.objects.all(),
+        label="کاربران",
+        required=False,
+        widget=forms.CheckboxSelectMultiple,
     )
 
 
 class MonthlyPerformanceForm(forms.Form):
     user = forms.ModelChoiceField(queryset=User.objects.all(), label="کاربر")
-    month = jforms.jDateField(label="ماه", widget=AdminjDateWidget())
+    year = forms.IntegerField(label="سال", initial=jdatetime.date.today().year)
+    MONTH_CHOICES = [
+        (1, "فروردین"),
+        (2, "اردیبهشت"),
+        (3, "خرداد"),
+        (4, "تیر"),
+        (5, "مرداد"),
+        (6, "شهریور"),
+        (7, "مهر"),
+        (8, "آبان"),
+        (9, "آذر"),
+        (10, "دی"),
+        (11, "بهمن"),
+        (12, "اسفند"),
+    ]
+    month = forms.ChoiceField(label="ماه", choices=MONTH_CHOICES, initial=jdatetime.date.today().month)

--- a/core/forms.py
+++ b/core/forms.py
@@ -348,7 +348,7 @@ class ReportFilterForm(forms.Form):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields["users"].label_from_instance = (
-            lambda obj: f"{obj.personnel_code} – {obj.last_name}"
+            lambda obj: f"{obj.personnel_code} – {obj.first_name} {obj.last_name}"
         )
 
 

--- a/core/forms.py
+++ b/core/forms.py
@@ -4,8 +4,15 @@ from django_jalali import forms as jforms
 from django_jalali.admin.widgets import AdminjDateWidget
 import jdatetime
 from attendance import models as attendance_models
-from attendance.models import AttendanceLog, EditRequest, LeaveRequest, LOG_TYPE_CHOICES
-from attendance.models import WeeklyHoliday
+from attendance.models import (
+    AttendanceLog,
+    EditRequest,
+    LeaveRequest,
+    LOG_TYPE_CHOICES,
+    WeeklyHoliday,
+    Group,
+    Shift,
+)
 
 User = get_user_model()
 
@@ -302,3 +309,26 @@ class LeaveTypeForm(forms.ModelForm):
         model = attendance_models.LeaveType
         fields = ["name", "description"]
         labels = {"name": "نام", "description": "توضیح"}
+
+
+class ReportFilterForm(forms.Form):
+    start_date = jforms.jDateField(
+        label="از تاریخ", widget=AdminjDateWidget(), required=False
+    )
+    end_date = jforms.jDateField(
+        label="تا تاریخ", widget=AdminjDateWidget(), required=False
+    )
+    groups = forms.ModelMultipleChoiceField(
+        queryset=Group.objects.all(), label="گروه‌ها", required=False
+    )
+    shifts = forms.ModelMultipleChoiceField(
+        queryset=Shift.objects.all(), label="شیفت‌ها", required=False
+    )
+    users = forms.ModelMultipleChoiceField(
+        queryset=User.objects.all(), label="کاربران", required=False
+    )
+
+
+class MonthlyPerformanceForm(forms.Form):
+    user = forms.ModelChoiceField(queryset=User.objects.all(), label="کاربر")
+    month = jforms.jDateField(label="ماه", widget=AdminjDateWidget())

--- a/core/urls.py
+++ b/core/urls.py
@@ -12,6 +12,7 @@ urlpatterns = [
     path("logout/",           LogoutView.as_view(next_page="home"), name="logout"),
     path('management/dashboard/', views.management_dashboard, name='management_dashboard'),
     path('management/reports/', views.user_reports, name='management_reports'),
+    path('management/reports/monthly/', views.monthly_profile, name='monthly_profile'),
     path('management/suspicions/', views.suspicious_logs, name='suspicious_logs'),
     path('management/edit-requests/', views.edit_requests, name='edit_requests'),
     path('management/edit-requests/add-log/', views.add_log, name='add_log'),

--- a/core/views.py
+++ b/core/views.py
@@ -719,8 +719,7 @@ def user_reports(request):
     # محاسبات آماری
     active_users = User.objects.filter(is_active=True).count()
     inactive_users = User.objects.filter(is_active=False).count()
-    users_with_face = User.objects.filter(face_encoding__isnull=False).count()
-    users_without_face = User.objects.filter(face_encoding__isnull=True).count()
+    # آمار ثبت چهره حذف شد
 
     form = ReportFilterForm(request.GET or None)
     logs_qs = AttendanceLog.objects.select_related('user').order_by('-timestamp')
@@ -744,8 +743,6 @@ def user_reports(request):
         'active_tab': 'reports',
         'active_users': active_users,
         'inactive_users': inactive_users,
-        'users_with_face': users_with_face,
-        'users_without_face': users_without_face,
         'logs': logs,
         'form': form,
     }

--- a/core/views.py
+++ b/core/views.py
@@ -719,7 +719,7 @@ def user_reports(request):
     # محاسبات آماری
     active_users = User.objects.filter(is_active=True).count()
     inactive_users = User.objects.filter(is_active=False).count()
-    # آمار ثبت چهره حذف شد
+    no_face_users = User.objects.filter(face_encoding__isnull=True).count()
 
     form = ReportFilterForm(request.GET or None)
     logs_qs = AttendanceLog.objects.select_related('user').order_by('-timestamp')
@@ -743,6 +743,7 @@ def user_reports(request):
         'active_tab': 'reports',
         'active_users': active_users,
         'inactive_users': inactive_users,
+        'no_face_users': no_face_users,
         'logs': logs,
         'form': form,
     }

--- a/static/core/management.css
+++ b/static/core/management.css
@@ -299,14 +299,57 @@
 }
 .charts-grid canvas { flex: 0 0 220px; }
 
-.report-filter .form-grid {
+.report-filter-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
   gap: 1rem;
 }
-.report-filter .form-grid div {
+
+.filter-card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: 1rem;
+  box-shadow: var(--shadow);
+}
+
+.filter-card h4 {
+  margin: 0 0 0.5rem 0;
+  font-size: 1rem;
+  color: var(--color-primary-dark);
+}
+
+.date-row {
   display: flex;
-  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.date-field {
+  flex: 1;
+  position: relative;
+}
+
+.date-field i {
+  position: absolute;
+  left: 0.5rem;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--color-muted);
+}
+
+.date-field input {
+  width: 100%;
+  padding-left: 2rem;
+}
+
+.multi-select {
+  width: 100%;
+}
+
+@media (max-width: 600px) {
+  .date-row {
+    flex-direction: column;
+  }
 }
 .report-result .table-responsive { overflow-x: auto; }
 

--- a/static/core/management.css
+++ b/static/core/management.css
@@ -346,8 +346,20 @@
   width: 100%;
 }
 
+.select-row {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.select-field {
+  flex: 1;
+}
+
 @media (max-width: 600px) {
   .date-row {
+    flex-direction: column;
+  }
+  .select-row {
     flex-direction: column;
   }
 }

--- a/static/core/management.css
+++ b/static/core/management.css
@@ -286,7 +286,6 @@
 
 /* small-screen adjustments */
 @media (max-width: 900px) {
-  .table-responsive, .management-table { display: none; }
   .request-cards { display: flex; flex-direction: column; gap: 1rem; }
 }
 
@@ -327,24 +326,11 @@
 
 .date-field {
   flex: 1 1 140px;
-  position: relative;
-}
-
-.date-field i {
-  position: absolute;
-  right: .5rem;
-  left: auto;
-  top: 50%;
-  transform: translateY(-50%);
-  pointer-events: none;
-  color: var(--color-muted);
 }
 
 .date-field input {
   width: 100%;
   box-sizing: border-box;
-  padding-right: 2rem;
-  padding-left: .75rem;
 }
 
 .multi-select {

--- a/static/core/management.css
+++ b/static/core/management.css
@@ -320,9 +320,9 @@
 }
 
 .date-row {
-  display: flex;
-  gap: 0.5rem;
-  flex-wrap: wrap;
+  display:flex;
+  gap:.75rem;
+  flex-wrap:wrap;
 }
 
 .date-field {
@@ -332,15 +332,19 @@
 
 .date-field i {
   position: absolute;
-  left: 0.5rem;
+  right: .5rem;
+  left: auto;
   top: 50%;
   transform: translateY(-50%);
+  pointer-events: none;
   color: var(--color-muted);
 }
 
 .date-field input {
   width: 100%;
-  padding-left: 2rem;
+  box-sizing: border-box;
+  padding-right: 2rem;
+  padding-left: .75rem;
 }
 
 .multi-select {

--- a/static/core/management.css
+++ b/static/core/management.css
@@ -299,6 +299,17 @@
 }
 .charts-grid canvas { flex: 0 0 220px; }
 
+.report-filter .form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+.report-filter .form-grid div {
+  display: flex;
+  flex-direction: column;
+}
+.report-result .table-responsive { overflow-x: auto; }
+
 @media (min-width: 900px) {
   .management-layout {
     flex-direction: row;

--- a/static/core/management.css
+++ b/static/core/management.css
@@ -301,7 +301,7 @@
 
 .report-filter-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   gap: 1rem;
 }
 
@@ -322,10 +322,11 @@
 .date-row {
   display: flex;
   gap: 0.5rem;
+  flex-wrap: wrap;
 }
 
 .date-field {
-  flex: 1;
+  flex: 1 1 140px;
   position: relative;
 }
 

--- a/templates/core/base_management.html
+++ b/templates/core/base_management.html
@@ -18,9 +18,13 @@
       <a href="{% url 'management_users' %}" class="{% if request.resolver_match.url_name == 'management_users' %}active{% endif %}">
         <i class="fas fa-users"></i> کاربران
       </a>
-      <a href="{% url 'management_reports' %}" class="{% if request.resolver_match.url_name == 'management_reports' %}active{% endif %}">
-        <i class="fas fa-file-alt"></i> گزارش‌ها
-      </a>
+      <details class="sidebar-group {% if request.resolver_match.url_name == 'management_reports' or request.resolver_match.url_name == 'monthly_profile' %}open{% endif %}">
+        <summary><i class="fas fa-file-alt"></i> گزارش‌ها</summary>
+        <nav class="sub-menu">
+          <a href="{% url 'management_reports' %}" class="{% if request.resolver_match.url_name == 'management_reports' %}active{% endif %}">گزارش کاربران</a>
+          <a href="{% url 'monthly_profile' %}" class="{% if request.resolver_match.url_name == 'monthly_profile' %}active{% endif %}">پروفایل ماهانه</a>
+        </nav>
+      </details>
         <a href="{% url 'suspicious_logs' %}" class="{% if request.resolver_match.url_name == 'suspicious_logs' %}active{% endif %}">
           <i class="fas fa-exclamation-triangle"></i> موارد مشکوک
         </a>

--- a/templates/core/monthly_profile.html
+++ b/templates/core/monthly_profile.html
@@ -5,23 +5,32 @@
 <h2 style="text-align:right;">
   <i class="fas fa-user-clock" style="margin-left:0.5rem;"></i> پروفایل عملکرد ماهانه
 </h2>
-<form method="get" class="card" style="margin-top:1rem;">
-  {{ form.as_p }}
+<form method="get" class="card report-filter" style="margin-top:1rem;">
+  <div class="form-grid">
+    <div>{{ form.user.label_tag }}{{ form.user }}</div>
+    <div>{{ form.year.label_tag }}{{ form.year }}</div>
+    <div>{{ form.month.label_tag }}{{ form.month }}</div>
+  </div>
   <button type="submit" class="btn">نمایش</button>
 </form>
 {% if report %}
+<h3 style="margin-top:1rem;">گزارش {{ selected_user.get_full_name }}</h3>
+<div class="dashboard-stats" style="margin-top:0;">
+  <div class="dashboard-card"><div class="value">{{ report.required_hours }}</div><div class="label">ساعات موظفی</div></div>
+  <div class="dashboard-card"><div class="value">{{ report.present_hours }}</div><div class="label">ساعات حضور</div></div>
+  <div class="dashboard-card"><div class="value">{{ report.overtime_minutes }}</div><div class="label">اضافه/کسری (دقیقه)</div></div>
+  <div class="dashboard-card"><div class="value">{{ report.absence_days }}</div><div class="label">روز غیبت</div></div>
+  <div class="dashboard-card"><div class="value">{{ report.tardy_minutes }}</div><div class="label">دقایق تأخیر</div></div>
+</div>
+{% if leaves %}
 <div class="card" style="margin-top:1rem;">
-  <h3>گزارش {{ selected_user.get_full_name }}</h3>
-  <p>مجموع دقایق حضور: {{ report.total_minutes }}</p>
-  <p>تعداد ترددها: {{ report.log_count }}</p>
-  {% if leaves %}
   <h4>مرخصی‌ها</h4>
   <ul>
     {% for l in leaves %}
       <li>{{ l.start_date|jformat:"%Y/%m/%d" }} تا {{ l.end_date|jformat:"%Y/%m/%d" }}</li>
     {% endfor %}
   </ul>
-  {% endif %}
 </div>
+{% endif %}
 {% endif %}
 {% endblock %}

--- a/templates/core/monthly_profile.html
+++ b/templates/core/monthly_profile.html
@@ -1,0 +1,27 @@
+{% extends "core/base_management.html" %}
+{% load jformat %}
+{% block title %}پروفایل ماهانه{% endblock %}
+{% block management_content %}
+<h2 style="text-align:right;">
+  <i class="fas fa-user-clock" style="margin-left:0.5rem;"></i> پروفایل عملکرد ماهانه
+</h2>
+<form method="get" class="card" style="margin-top:1rem;">
+  {{ form.as_p }}
+  <button type="submit" class="btn">نمایش</button>
+</form>
+{% if report %}
+<div class="card" style="margin-top:1rem;">
+  <h3>گزارش {{ selected_user.get_full_name }}</h3>
+  <p>مجموع دقایق حضور: {{ report.total_minutes }}</p>
+  <p>تعداد ترددها: {{ report.log_count }}</p>
+  {% if leaves %}
+  <h4>مرخصی‌ها</h4>
+  <ul>
+    {% for l in leaves %}
+      <li>{{ l.start_date|jformat:"%Y/%m/%d" }} تا {{ l.end_date|jformat:"%Y/%m/%d" }}</li>
+    {% endfor %}
+  </ul>
+  {% endif %}
+</div>
+{% endif %}
+{% endblock %}

--- a/templates/core/user_reports.html
+++ b/templates/core/user_reports.html
@@ -96,15 +96,11 @@
 {% endblock %}
 
 {% block extra_js %}
-<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 {{ form.media }}
 <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
 <script>
   $(function() {
     $('.multi-select').select2({width: '100%', dir: 'rtl'});
-    $('.date-field i').on('click', function(){
-      $(this).siblings('input').focus();
-    });
   });
 </script>
 {% endblock %}

--- a/templates/core/user_reports.html
+++ b/templates/core/user_reports.html
@@ -5,7 +5,6 @@
 <h2 style="text-align:right;">
   <i class="fas fa-file-alt" style="margin-left:0.5rem;"></i> گزارش کاربران
  </h2>
-<a href="{% url 'monthly_profile' %}" class="btn" style="margin-top:0.5rem;">پروفایل ماهانه کاربر</a>
 <div class="dashboard-stats">
   <div class="dashboard-card">
     <h3>{{ active_users }}</h3>
@@ -14,14 +13,6 @@
   <div class="dashboard-card">
     <h3>{{ inactive_users }}</h3>
     کاربر غیرفعال
-  </div>
-  <div class="dashboard-card">
-    <h3>{{ users_with_face }}</h3>
-    با ثبت چهره
-  </div>
-  <div class="dashboard-card">
-    <h3>{{ users_without_face }}</h3>
-    بدون ثبت چهره
   </div>
 </div>
 
@@ -43,12 +34,16 @@
       </div>
     </div>
     <div class="filter-card">
-      <h4>{{ form.groups.label }}</h4>
-      {{ form.groups }}
-    </div>
-    <div class="filter-card">
-      <h4>{{ form.shifts.label }}</h4>
-      {{ form.shifts }}
+      <div class="select-row">
+        <div class="select-field">
+          <h4>{{ form.groups.label }}</h4>
+          {{ form.groups }}
+        </div>
+        <div class="select-field">
+          <h4>{{ form.shifts.label }}</h4>
+          {{ form.shifts }}
+        </div>
+      </div>
     </div>
     <div class="filter-card">
       <h4>{{ form.users.label }}</h4>
@@ -73,7 +68,7 @@
       <tbody>
         {% for log in logs %}
         <tr>
-          <td>{{ log.user.personnel_code }} – {{ log.user.last_name }}</td>
+          <td>{{ log.user.personnel_code }} – {{ log.user.first_name }} {{ log.user.last_name }}</td>
           <td>{{ log.timestamp|jformat:"%Y/%m/%d" }}</td>
           <td>{{ log.timestamp|time:"H:i" }}</td>
           <td>{% if log.log_type == 'in' %}ورود{% else %}خروج{% endif %}</td>
@@ -100,6 +95,9 @@
 <script>
   $(function() {
     $('.multi-select').select2({width: '100%', dir: 'rtl'});
+    $('.date-field i').on('click', function(){
+      $(this).siblings('input').focus();
+    });
   });
 </script>
 {% endblock %}

--- a/templates/core/user_reports.html
+++ b/templates/core/user_reports.html
@@ -7,12 +7,19 @@
  </h2>
 <div class="dashboard-stats">
   <div class="dashboard-card">
-    <h3>{{ active_users }}</h3>
-    کاربر فعال
+    <i class="fas fa-user-check"></i>
+    <div class="value">{{ active_users }}</div>
+    <div class="label">کاربر فعال</div>
   </div>
   <div class="dashboard-card">
-    <h3>{{ inactive_users }}</h3>
-    کاربر غیرفعال
+    <i class="fas fa-user-times"></i>
+    <div class="value">{{ inactive_users }}</div>
+    <div class="label">کاربر غیرفعال</div>
+  </div>
+  <div class="dashboard-card">
+    <i class="fas fa-user-slash"></i>
+    <div class="value">{{ no_face_users }}</div>
+    <div class="label">بدون ثبت چهره</div>
   </div>
 </div>
 

--- a/templates/core/user_reports.html
+++ b/templates/core/user_reports.html
@@ -4,7 +4,7 @@
 {% block management_content %}
 <h2 style="text-align:right;">
   <i class="fas fa-file-alt" style="margin-left:0.5rem;"></i> گزارش کاربران
-</h2>
+ </h2>
 <a href="{% url 'monthly_profile' %}" class="btn" style="margin-top:0.5rem;">پروفایل ماهانه کاربر</a>
 <div class="dashboard-stats">
   <div class="dashboard-card">
@@ -25,47 +25,81 @@
   </div>
 </div>
 
-<form method="get" class="card report-filter" style="margin-top:1rem;">
-  <div class="form-grid">
-    <div>{{ form.start_date.label_tag }}{{ form.start_date }}</div>
-    <div>{{ form.end_date.label_tag }}{{ form.end_date }}</div>
-    <div>{{ form.groups.label_tag }}{{ form.groups }}</div>
-    <div>{{ form.shifts.label_tag }}{{ form.shifts }}</div>
-    <div>{{ form.users.label_tag }}{{ form.users }}</div>
+<form method="get" class="report-filter" style="margin-top:1rem;">
+  <div class="report-filter-grid">
+    <div class="filter-card">
+      <h4>بازه تاریخ</h4>
+      <div class="date-row">
+        <div class="date-field">
+          {{ form.start_date.label_tag }}
+          {{ form.start_date }}
+          <i class="fas fa-calendar-alt"></i>
+        </div>
+        <div class="date-field">
+          {{ form.end_date.label_tag }}
+          {{ form.end_date }}
+          <i class="fas fa-calendar-alt"></i>
+        </div>
+      </div>
+    </div>
+    <div class="filter-card">
+      <h4>{{ form.groups.label }}</h4>
+      {{ form.groups }}
+    </div>
+    <div class="filter-card">
+      <h4>{{ form.shifts.label }}</h4>
+      {{ form.shifts }}
+    </div>
+    <div class="filter-card">
+      <h4>{{ form.users.label }}</h4>
+      {{ form.users }}
+    </div>
   </div>
   <button type="submit" class="btn">تولید گزارش</button>
 </form>
 
 <div class="card report-result" style="margin-top:1rem;">
-<div class="table-responsive">
-<table class="management-table">
-  <thead>
-    <tr>
-      <th>کاربر</th>
-      <th>تاریخ</th>
-      <th>ساعت</th>
-      <th>نوع</th>
-      <th>ثبت‌کننده</th>
-    </tr>
-  </thead>
-  <tbody>
-    {% for log in logs %}
-    <tr>
-      <td>{{ log.user.get_full_name }} - {{ log.user.personnel_code }}</td>
-      <td>{{ log.timestamp|jformat:"%Y/%m/%d" }}</td>
-      <td>{{ log.timestamp|time:"H:i" }}</td>
-      <td>{% if log.log_type == 'in' %}ورود{% else %}خروج{% endif %}</td>
-      <td>{% if log.source == 'self' %}کاربر{% elif log.source == 'auto' %}سیستم{% else %}مدیر{% endif %}</td>
-    </tr>
-    {% empty %}
-    <tr><td colspan="5">ترددی ثبت نشده است.</td></tr>
-    {% endfor %}
-  </tbody>
-</table>
-</div>
+  <div class="table-responsive">
+    <table class="management-table">
+      <thead>
+        <tr>
+          <th>کاربر</th>
+          <th>تاریخ</th>
+          <th>ساعت</th>
+          <th>نوع</th>
+          <th>ثبت‌کننده</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for log in logs %}
+        <tr>
+          <td>{{ log.user.personnel_code }} – {{ log.user.last_name }}</td>
+          <td>{{ log.timestamp|jformat:"%Y/%m/%d" }}</td>
+          <td>{{ log.timestamp|time:"H:i" }}</td>
+          <td>{% if log.log_type == 'in' %}ورود{% else %}خروج{% endif %}</td>
+          <td>{% if log.source == 'self' %}کاربر{% elif log.source == 'auto' %}سیستم{% else %}مدیر{% endif %}</td>
+        </tr>
+        {% empty %}
+        <tr><td colspan="5">ترددی ثبت نشده است.</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
 </div>
 {% endblock %}
 
+{% block extra_css %}
+{{ block.super }}
+<link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
+{% endblock %}
+
 {% block extra_js %}
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 {{ form.media }}
+<script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
+<script>
+  $(function() {
+    $('.multi-select').select2({width: '100%', dir: 'rtl'});
+  });
+</script>
 {% endblock %}

--- a/templates/core/user_reports.html
+++ b/templates/core/user_reports.html
@@ -31,12 +31,10 @@
         <div class="date-field">
           {{ form.start_date.label_tag }}
           {{ form.start_date }}
-          <i class="fas fa-calendar-alt"></i>
         </div>
         <div class="date-field">
           {{ form.end_date.label_tag }}
           {{ form.end_date }}
-          <i class="fas fa-calendar-alt"></i>
         </div>
       </div>
     </div>

--- a/templates/core/user_reports.html
+++ b/templates/core/user_reports.html
@@ -19,24 +19,17 @@
     با ثبت چهره
   </div>
 </div>
-<div class="card charts-grid fade-in" style="margin-top:1rem;">
+<div class="card charts-grid fade-in" style="margin-top:1rem;max-width:400px;">
   <canvas id="statusChart" height="160"></canvas>
   <canvas id="faceChart" height="160"></canvas>
 </div>
-<div class="request-cards mobile-only">
-  {% for log in latest_logs %}
-  <div class="request-card fade-in">
-    <div class="row"><span class="label">کاربر:</span><span>{{ log.user.get_full_name }} - {{ log.user.personnel_code }}</span></div>
-    <div class="row"><span class="label">تاریخ:</span><span>{{ log.timestamp|jformat:"%Y/%m/%d" }}</span></div>
-    <div class="row"><span class="label">ساعت:</span><span>{{ log.timestamp|time:"H:i" }}</span></div>
-    <div class="row"><span class="label">نوع:</span><span>{% if log.log_type == 'in' %}ورود{% else %}خروج{% endif %}</span></div>
-    <div class="row"><span class="label">ثبت‌کننده:</span><span>{% if log.source == 'self' %}کاربر{% elif log.source == 'auto' %}سیستم{% else %}مدیر{% endif %}</span></div>
-  </div>
-  {% empty %}
-  <div class="alert-error">ترددی ثبت نشده است.</div>
-  {% endfor %}
-</div>
-<div class="table-responsive desktop-only">
+
+<form method="get" class="card" style="margin-top:1rem;">
+  {{ form.as_p }}
+  <button type="submit" class="btn">تولید گزارش</button>
+</form>
+
+<div class="table-responsive" style="margin-top:1rem;">
 <table class="management-table">
   <thead>
     <tr>
@@ -48,7 +41,7 @@
     </tr>
   </thead>
   <tbody>
-    {% for log in latest_logs %}
+    {% for log in logs %}
     <tr>
       <td>{{ log.user.get_full_name }} - {{ log.user.personnel_code }}</td>
       <td>{{ log.timestamp|jformat:"%Y/%m/%d" }}</td>

--- a/templates/core/user_reports.html
+++ b/templates/core/user_reports.html
@@ -5,6 +5,7 @@
 <h2 style="text-align:right;">
   <i class="fas fa-file-alt" style="margin-left:0.5rem;"></i> گزارش کاربران
 </h2>
+<a href="{% url 'monthly_profile' %}" class="btn" style="margin-top:0.5rem;">پروفایل ماهانه کاربر</a>
 <div class="dashboard-stats">
   <div class="dashboard-card">
     <h3>{{ active_users }}</h3>
@@ -18,18 +19,25 @@
     <h3>{{ users_with_face }}</h3>
     با ثبت چهره
   </div>
-</div>
-<div class="card charts-grid fade-in" style="margin-top:1rem;max-width:400px;">
-  <canvas id="statusChart" height="160"></canvas>
-  <canvas id="faceChart" height="160"></canvas>
+  <div class="dashboard-card">
+    <h3>{{ users_without_face }}</h3>
+    بدون ثبت چهره
+  </div>
 </div>
 
-<form method="get" class="card" style="margin-top:1rem;">
-  {{ form.as_p }}
+<form method="get" class="card report-filter" style="margin-top:1rem;">
+  <div class="form-grid">
+    <div>{{ form.start_date.label_tag }}{{ form.start_date }}</div>
+    <div>{{ form.end_date.label_tag }}{{ form.end_date }}</div>
+    <div>{{ form.groups.label_tag }}{{ form.groups }}</div>
+    <div>{{ form.shifts.label_tag }}{{ form.shifts }}</div>
+    <div>{{ form.users.label_tag }}{{ form.users }}</div>
+  </div>
   <button type="submit" class="btn">تولید گزارش</button>
 </form>
 
-<div class="table-responsive" style="margin-top:1rem;">
+<div class="card report-result" style="margin-top:1rem;">
+<div class="table-responsive">
 <table class="management-table">
   <thead>
     <tr>
@@ -55,33 +63,9 @@
   </tbody>
 </table>
 </div>
+</div>
 {% endblock %}
 
 {% block extra_js %}
-<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-<script>
-const statusData = {{ status_data_json|safe }};
-new Chart(document.getElementById('statusChart').getContext('2d'), {
-  type: 'doughnut',
-  data: {
-    labels: ['فعال', 'غیرفعال'],
-    datasets: [{
-      data: statusData,
-      backgroundColor: ['#4caf50', '#f44336']
-    }]
-  }
-});
-
-const faceData = {{ face_data_json|safe }};
-new Chart(document.getElementById('faceChart').getContext('2d'), {
-  type: 'doughnut',
-  data: {
-    labels: ['با چهره', 'بدون چهره'],
-    datasets: [{
-      data: faceData,
-      backgroundColor: ['#2196f3', '#9e9e9e']
-    }]
-  }
-});
-</script>
+{{ form.media }}
 {% endblock %}


### PR DESCRIPTION
## Summary
- add custom filter form for user reports with date, group, shift and user filters
- create monthly performance profile page with basic presence and leave info
- streamline user report page layout

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68966e900198833385b60bbc006ded3b