### PR TITLE
Improve shift, group and holiday management UX

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -5,6 +5,7 @@ import secrets
 from datetime import timedelta, datetime, time
 
 import face_recognition
+import holidays
 import numpy as np
 from PIL import Image
 from django.contrib import messages
@@ -21,6 +22,7 @@ from django.urls import reverse
 from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
+from django.db.models import Q
 
 from attendance.models import (
     AttendanceLog,
@@ -1000,7 +1002,26 @@ def weekly_holidays(request):
             existing = set(days)
     else:
         form = WeeklyHolidayForm(initial={"days": [str(d) for d in existing]})
-    return render(request, "core/weekly_holidays.html", {"form": form, "active_tab": "weekly_holidays"})
+
+    iran_holidays = holidays.Iran()
+    today = datetime.today().date()
+    upcoming = [
+        (jdatetime.date.fromgregorian(date=d), name)
+        for d, name in iran_holidays.items()
+        if d >= today
+    ]
+    upcoming.sort(key=lambda x: x[0].togregorian())
+    upcoming = upcoming[:10]
+
+    return render(
+        request,
+        "core/weekly_holidays.html",
+        {
+            "form": form,
+            "active_tab": "weekly_holidays",
+            "official_holidays": upcoming,
+        },
+    )
 
 
 @login_required
@@ -1042,8 +1063,16 @@ def device_settings(request):
 def shift_list(request):
     if not request.session.get("face_verified"):
         return redirect("management_face_check")
-    shifts = Shift.objects.all()
-    return render(request, "core/shift_list.html", {"shifts": shifts, "active_tab": "settings"})
+    shifts = list(Shift.objects.all())
+    for s in shifts:
+        s.user_count = CustomUser.objects.filter(
+            Q(shift=s) | Q(group__shift=s)
+        ).distinct().count()
+    return render(
+        request,
+        "core/shift_list.html",
+        {"shifts": shifts, "active_tab": "settings"},
+    )
 
 
 @login_required
@@ -1069,11 +1098,24 @@ def shift_delete(request, pk):
     if not request.session.get("face_verified"):
         return redirect("management_face_check")
     shift = get_object_or_404(Shift, pk=pk)
+    affected_users = (
+        CustomUser.objects.filter(Q(shift=shift) | Q(group__shift=shift))
+        .distinct()
+        .count()
+    )
     if request.method == "POST":
         shift.delete()
         messages.success(request, "حذف شد.")
         return redirect("shift_list")
-    return render(request, "core/confirm_delete.html", {"object": shift, "cancel_url": "shift_list"})
+    return render(
+        request,
+        "core/confirm_delete.html",
+        {
+            "object": shift,
+            "cancel_url": "shift_list",
+            "affected_users": affected_users,
+        },
+    )
 
 
 @login_required
@@ -1081,8 +1123,14 @@ def shift_delete(request, pk):
 def group_list(request):
     if not request.session.get("face_verified"):
         return redirect("management_face_check")
-    groups = Group.objects.select_related("shift").all()
-    return render(request, "core/group_list.html", {"groups": groups, "active_tab": "settings"})
+    groups = list(Group.objects.select_related("shift").all())
+    for g in groups:
+        g.user_count = CustomUser.objects.filter(group=g).count()
+    return render(
+        request,
+        "core/group_list.html",
+        {"groups": groups, "active_tab": "settings"},
+    )
 
 
 @login_required
@@ -1108,11 +1156,20 @@ def group_delete(request, pk):
     if not request.session.get("face_verified"):
         return redirect("management_face_check")
     grp = get_object_or_404(Group, pk=pk)
+    affected_users = CustomUser.objects.filter(group=grp).count()
     if request.method == "POST":
         grp.delete()
         messages.success(request, "حذف شد.")
         return redirect("group_list")
-    return render(request, "core/confirm_delete.html", {"object": grp, "cancel_url": "group_list"})
+    return render(
+        request,
+        "core/confirm_delete.html",
+        {
+            "object": grp,
+            "cancel_url": "group_list",
+            "affected_users": affected_users,
+        },
+    )
 
 
 @login_required

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ opencv-python
 jdatetime
 numpy
 django_jalali
+holidays

--- a/templates/core/confirm_delete.html
+++ b/templates/core/confirm_delete.html
@@ -3,7 +3,11 @@
 {% block management_content %}
 <h2 class="page-title"><i class="fas fa-trash-alt"></i> حذف</h2>
 <div class="card">
+  {% if affected_users is not None %}
+  <p>حذف <b>{{ object }}</b> بر {{ affected_users }} کاربر تأثیر خواهد گذاشت. آیا مطمئن هستید؟</p>
+  {% else %}
   <p>آیا از حذف <b>{{ object }}</b> مطمئن هستید؟</p>
+  {% endif %}
   <form method="post">
     {% csrf_token %}
     <button type="submit" class="btn alert-error">حذف</button>

--- a/templates/core/group_list.html
+++ b/templates/core/group_list.html
@@ -13,7 +13,7 @@
   <tbody>
   {% for g in groups %}
     <tr>
-      <td>{{ g.name }}</td>
+      <td>{{ g.name }} <span style="color:var(--color-muted);">({{ g.user_count }} کاربر)</span></td>
       <td>{{ g.shift }}</td>
       <td>
         <a href="{% url 'group_edit' g.pk %}"><i class="fas fa-edit"></i></a>

--- a/templates/core/shift_list.html
+++ b/templates/core/shift_list.html
@@ -13,7 +13,7 @@
   <tbody>
   {% for s in shifts %}
     <tr>
-      <td>{{ s.name }}</td>
+      <td>{{ s.name }} <span style="color:var(--color-muted);">({{ s.user_count }} کاربر)</span></td>
       <td>{{ s.start_time|time:"H:i" }}</td>
       <td>{{ s.end_time|time:"H:i" }}</td>
       <td>

--- a/templates/core/weekly_holidays.html
+++ b/templates/core/weekly_holidays.html
@@ -5,11 +5,44 @@
 <form method="post" class="card page page-sm form-grid" style="margin-top:1rem;">
   {% csrf_token %}
   <h3 class="panel-title" style="grid-column:1/-1;">{{ form.days.label }}</h3>
-  {% for checkbox in form.days %}
-    <label class="form-group">{{ checkbox.tag }} {{ checkbox.choice_label }}</label>
-  {% endfor %}
+  <div id="week-calendar" class="week-calendar" style="grid-column:1/-1;">
+    {% for checkbox in form.days %}
+      <div class="day{% if checkbox.data %} selected{% endif %}" data-checkbox-id="{{ checkbox.id_for_label }}">
+        {{ checkbox.choice_label }}
+        {{ checkbox.tag }}
+      </div>
+    {% endfor %}
+  </div>
   <div class="profile-actions" style="grid-column:1/-1;">
     <button class="btn" type="submit">ذخیره</button>
   </div>
 </form>
+
+{% if official_holidays %}
+<div class="card" style="margin-top:1rem;">
+  <h3 class="panel-title">تعطیلات رسمی پیش‌رو</h3>
+  <ul class="official-holidays">
+    {% for d, name in official_holidays %}
+      <li>{{ d.strftime('%Y/%m/%d') }} - {{ name }}</li>
+    {% endfor %}
+  </ul>
+</div>
+{% endif %}
+
+<style>
+.week-calendar {display:flex;gap:0.5rem;flex-wrap:wrap;}
+.week-calendar .day {cursor:pointer;padding:1rem;border:1px solid #ccc;border-radius:4px;min-width:80px;text-align:center;}
+.week-calendar .day.selected {background:var(--color-primary);color:#fff;}
+.week-calendar input[type=checkbox]{display:none;}
+</style>
+
+<script>
+document.querySelectorAll('#week-calendar .day').forEach(function(el){
+  el.addEventListener('click', function(){
+    const cb = document.getElementById(el.dataset.checkboxId);
+    cb.checked = !cb.checked;
+    el.classList.toggle('selected');
+  });
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- show assigned user counts in shift and group lists
- warn about affected users before deleting shifts and groups
- replace weekly holidays checkboxes with clickable calendar and show upcoming official holidays

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68966fd818348333bbbc35ea8be5284f