### PR TITLE
Revamp user profile dashboard

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -301,7 +301,124 @@ def user_profile(request):
     if not uid:
         return redirect("user_inquiry")
     u = get_object_or_404(User, id=uid)
-    return render(request, "core/user_profile.html", {"user": u})
+
+    today = timezone.now().date()
+    is_holiday = WeeklyHoliday.objects.filter(weekday=today.weekday()).exists()
+    on_leave = LeaveRequest.objects.filter(
+        user=u,
+        status="approved",
+        start_date__lte=today,
+        end_date__gte=today,
+    ).exists()
+    first_log = (
+        AttendanceLog.objects.filter(user=u, timestamp__date=today)
+        .order_by("timestamp")
+        .first()
+    )
+    if is_holiday:
+        today_status = {"label": "روز تعطیل", "color": "gray"}
+    elif on_leave:
+        today_status = {"label": "مرخصی", "color": "blue"}
+    elif first_log:
+        today_status = {
+            "label": "حاضر",
+            "color": "green",
+            "in_time": first_log.timestamp.time(),
+        }
+    else:
+        today_status = {"label": "غایب", "color": "red"}
+
+    recent_items = []
+    status_map = {
+        "pending": "در انتظار بررسی",
+        "approved": "تأیید شد",
+        "rejected": "رد شد",
+        "cancelled": "لغو شد",
+    }
+    for lr in LeaveRequest.objects.filter(user=u).order_by("-created_at")[:4]:
+        jd = jdatetime.date.fromgregorian(date=lr.start_date)
+        msg = (
+            f"درخواست مرخصی شما برای تاریخ {jd.strftime('%Y/%m/%d')} "
+            f"{status_map.get(lr.status, lr.status)}"
+        )
+        recent_items.append({"created_at": lr.created_at, "message": msg})
+    for er in EditRequest.objects.filter(user=u).order_by("-created_at")[:4]:
+        ts = jdatetime.datetime.fromgregorian(datetime=er.timestamp)
+        msg = (
+            f"درخواست ویرایش تردد شما برای {ts.strftime('%Y/%m/%d %H:%M')} "
+            f"{status_map.get(er.status, er.status)}"
+        )
+        recent_items.append({"created_at": er.created_at, "message": msg})
+    recent_items = sorted(recent_items, key=lambda x: x["created_at"], reverse=True)[:4]
+
+    today_j = jdatetime.date.today()
+    jy, jm = today_j.year, today_j.month
+    days = jdatetime.j_days_in_month[jm - 1]
+    start_g = jdatetime.date(jy, jm, 1).togregorian()
+    end_g = jdatetime.date(jy, jm, days).togregorian()
+    logs = AttendanceLog.objects.filter(
+        user=u, timestamp__date__range=(start_g, end_g)
+    ).order_by("timestamp")
+    shift = _get_user_shift(u)
+    shift_start = time(9, 0)
+    shift_end = time(17, 0)
+    if shift:
+        shift_start = shift.start_time
+        shift_end = shift.end_time
+
+    total_seconds = 0
+    tardy_minutes = 0
+    absent_days = 0
+    leave_days = 0
+    for d in range(1, days + 1):
+        gdate = jdatetime.date(jy, jm, d).togregorian()
+        if WeeklyHoliday.objects.filter(weekday=gdate.weekday()).exists():
+            continue
+        if LeaveRequest.objects.filter(
+            user=u,
+            status="approved",
+            start_date__lte=gdate,
+            end_date__gte=gdate,
+        ).exists():
+            leave_days += 1
+            continue
+        day_logs = [log for log in logs if log.timestamp.date() == gdate]
+        if day_logs:
+            first = min(day_logs, key=lambda l: l.timestamp)
+            last = max(day_logs, key=lambda l: l.timestamp)
+            start_dt = datetime.combine(gdate, shift_start)
+            end_dt = datetime.combine(gdate, shift_end)
+            f_dt = first.timestamp
+            if f_dt.tzinfo is not None:
+                f_dt = f_dt.replace(tzinfo=None)
+            if f_dt > start_dt:
+                tardy_minutes += int((f_dt - start_dt).total_seconds() / 60)
+            l_dt = last.timestamp
+            if l_dt.tzinfo is not None:
+                l_dt = l_dt.replace(tzinfo=None)
+            if l_dt < f_dt:
+                l_dt = f_dt
+            work_start = max(f_dt, start_dt)
+            work_end = min(l_dt, end_dt)
+            if work_end > work_start:
+                total_seconds += (work_end - work_start).total_seconds()
+        else:
+            absent_days += 1
+
+    monthly_stats = {
+        "total_hours": round(total_seconds / 3600, 1),
+        "tardy_minutes": tardy_minutes,
+        "absent_days": absent_days,
+        "leave_days": leave_days,
+    }
+
+    context = {
+        "user": u,
+        "today_status": today_status,
+        "recent_items": recent_items,
+        "monthly_stats": monthly_stats,
+    }
+    return render(request, "core/user_profile.html", context)
 
 
 def my_logs(request):

--- a/templates/core/user_profile.html
+++ b/templates/core/user_profile.html
@@ -1,23 +1,58 @@
 {% extends "core/base.html" %}
 {% load static %}
+{% load jformat %}
 {% block title %}پروفایل کاربر{% endblock %}
 {% block content %}
 <div class="card page page-md profile-card fade-in">
   <div class="profile-banner">
     <img class="profile-avatar" src="{% if user.face_image %}{{ user.face_image.url }}{% else %}{% static 'core/avatar.png' %}{% endif %}" alt="{{ user.get_full_name }}">
-    <h2 class="page-title">
-      <i class="fa fa-user"></i>
-      پروفایل {{ user.get_full_name }}
-    </h2>
+    <div class="profile-header-info">
+      <h2 class="page-title"><i class="fa fa-user"></i> پروفایل {{ user.get_full_name }}</h2>
+      <div class="profile-ids">
+        <span>کد پرسنلی: {{ user.personnel_code }}</span>
+        <span>کد ملی: {{ user.national_id }}</span>
+      </div>
+    </div>
   </div>
-  <ul class="profile-details">
-    <li>کد پرسنلی: {{ user.personnel_code }}</li>
-    <li>کد ملی: {{ user.national_id }}</li>
-  </ul>
+
+  <div class="status-widget status-{{ today_status.color }}">
+    <h3>وضعیت امروز شما</h3>
+    <p>
+      {{ today_status.label }}
+      {% if today_status.in_time %}- اولین ورود: {{ today_status.in_time|time:"H:i" }}{% endif %}
+    </p>
+  </div>
+
+  <div class="recent-widget">
+    <h3>آخرین اعلان‌ها و درخواست‌ها</h3>
+    <ul>
+      {% for n in recent_items %}
+      <li>{{ n.message }}</li>
+      {% empty %}
+      <li>اعلان جدیدی وجود ندارد.</li>
+      {% endfor %}
+    </ul>
+  </div>
+
+  <div class="stats-widget">
+    <h3>آمار عملکرد من در این ماه</h3>
+    <div class="stats-cards">
+      <div class="stat-card"><span class="label">ساعات کاری ثبت شده</span><span class="value">{{ monthly_stats.total_hours }}</span></div>
+      <div class="stat-card"><span class="label">دقایق تأخیر</span><span class="value">{{ monthly_stats.tardy_minutes }}</span></div>
+      <div class="stat-card"><span class="label">روزهای غیبت</span><span class="value">{{ monthly_stats.absent_days }}</span></div>
+      <div class="stat-card"><span class="label">روزهای مرخصی</span><span class="value">{{ monthly_stats.leave_days }}</span></div>
+    </div>
+  </div>
+
+  <div class="quick-actions">
+    <h3>دسترسی سریع</h3>
+    <a class="btn" href="{% url 'my_logs' %}"><i class="fa fa-list-alt" style="margin-left:0.4rem;"></i> مشاهده گزارش کامل تردد</a>
+    <a class="btn" href="{% url 'leave_request' %}"><i class="fa fa-calendar-plus" style="margin-left:0.4rem;"></i> ثبت درخواست جدید</a>
+    <a class="btn" href="{% url 'my_leave_requests' %}"><i class="fa fa-calendar-check" style="margin-left:0.4rem;"></i> پیگیری درخواست‌های من</a>
+  </div>
+
   <div class="profile-actions">
-    <a class="btn" href="{% url 'my_logs' %}"><i class="fa fa-list-alt" style="margin-left:0.4rem;"></i> مشاهده ترددها</a>
-    <a class="btn" href="{% url 'user_leave_requests' %}"><i class="fa fa-calendar" style="margin-left:0.4rem;"></i> مرخصی‌های من</a>
-    <a class="btn" href="{% url 'user_inquiry' %}"><i class="fas fa-chevron-right" style="margin-left:0.4rem;"></i> خروج</a>
+    <a class="btn" href="{% url 'user_inquiry' %}"><i class="fas fa-chevron-right" style="margin-left:0.4rem;"></i> بازگشت</a>
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Integrate personnel details into profile header and rename exit to back
- Add widgets for today's status, recent notifications, and monthly performance stats
- Compute status, notifications, and monthly metrics in user_profile view

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689671e90cf48333adf0a7069ce0ef1e