### PR TITLE
Revamp user profile into attendance dashboard

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -301,7 +301,144 @@ def user_profile(request):
     if not uid:
         return redirect("user_inquiry")
     u = get_object_or_404(User, id=uid)
-    return render(request, "core/user_profile.html", {"user": u})
+
+    today = timezone.localdate()
+    today_logs = AttendanceLog.objects.filter(user=u, timestamp__date=today).order_by("timestamp")
+    is_holiday = WeeklyHoliday.objects.filter(weekday=today.weekday()).exists()
+    on_leave = LeaveRequest.objects.filter(
+        user=u, status="approved", start_date__lte=today, end_date__gte=today
+    ).exists()
+
+    status_info = {"label": "", "color": "", "detail": None}
+    if is_holiday:
+        status_info.update({"label": "روز تعطیل", "color": "holiday"})
+    elif on_leave:
+        status_info.update({"label": "مرخصی", "color": "leave"})
+    elif today_logs.exists():
+        first_log = today_logs.first()
+        status_info.update(
+            {
+                "label": "حاضر",
+                "color": "present",
+                "detail": first_log.timestamp.strftime("%H:%M"),
+            }
+        )
+    else:
+        status_info.update({"label": "غایب", "color": "absent"})
+
+    edits = list(
+        EditRequest.objects.filter(user=u).order_by("-created_at")[:4]
+    )
+    leaves = list(
+        LeaveRequest.objects.filter(user=u).order_by("-created_at")[:4]
+    )
+    combined = edits + leaves
+    combined.sort(key=lambda x: x.created_at, reverse=True)
+    notifications = []
+    for obj in combined[:4]:
+        if isinstance(obj, EditRequest):
+            status_disp = dict(EditRequest.STATUS_CHOICES).get(obj.status, obj.status)
+            ts = jdatetime.datetime.fromgregorian(datetime=obj.timestamp).strftime(
+                "%Y/%m/%d %H:%M"
+            )
+            notifications.append(
+                f"درخواست ویرایش تردد برای {ts} {status_disp} است."
+            )
+        else:
+            status_disp = dict(LeaveRequest.STATUS_CHOICES).get(obj.status, obj.status)
+            start_j = jdatetime.date.fromgregorian(date=obj.start_date).strftime(
+                "%Y/%m/%d"
+            )
+            end_j = jdatetime.date.fromgregorian(date=obj.end_date).strftime(
+                "%Y/%m/%d"
+            )
+            notifications.append(
+                f"درخواست مرخصی برای {start_j} تا {end_j} {status_disp} است."
+            )
+
+    today_j = jdatetime.date.today()
+    jy, jm = today_j.year, today_j.month
+    days = jdatetime.j_days_in_month[jm - 1]
+    start_g = jdatetime.date(jy, jm, 1).togregorian()
+    end_g = jdatetime.date(jy, jm, days).togregorian()
+    logs_qs = AttendanceLog.objects.filter(
+        user=u, timestamp__date__range=(start_g, end_g)
+    ).order_by("timestamp")
+    logs_by_day = {}
+    for log in logs_qs:
+        jd = jdatetime.date.fromgregorian(date=log.timestamp.date())
+        logs_by_day.setdefault(jd.day, []).append(log)
+
+    week_holidays = set(WeeklyHoliday.objects.values_list("weekday", flat=True))
+    total_seconds = 0
+    tardy_minutes = 0
+    absent_days = 0
+    for day in range(1, days + 1):
+        jd = jdatetime.date(jy, jm, day)
+        gdate = jd.togregorian()
+        if gdate > today:
+            break
+        if jd.weekday() in week_holidays:
+            continue
+        leave_day = LeaveRequest.objects.filter(
+            user=u, status="approved", start_date__lte=gdate, end_date__gte=gdate
+        ).exists()
+        if leave_day:
+            continue
+        day_logs = logs_by_day.get(day, [])
+        if not day_logs:
+            absent_days += 1
+            continue
+        day_logs.sort(key=lambda l: l.timestamp)
+        first_log = day_logs[0]
+        last_log = day_logs[-1]
+        shift = _get_user_shift(u)
+        shift_start = time(9, 0)
+        shift_end = time(17, 0)
+        if shift:
+            shift_start = shift.start_time
+            shift_end = shift.end_time
+        start_dt = datetime.combine(gdate, shift_start)
+        end_dt = datetime.combine(gdate, shift_end)
+        if shift_end <= shift_start:
+            end_dt += timedelta(days=1)
+        if first_log.timestamp > start_dt:
+            tardy_minutes += int(
+                (first_log.timestamp - start_dt).total_seconds() / 60
+            )
+        last_dt = last_log.timestamp
+        if last_dt < first_log.timestamp:
+            last_dt = first_log.timestamp
+        work_start = max(first_log.timestamp, start_dt)
+        work_end = min(last_dt, end_dt)
+        if work_end > work_start:
+            total_seconds += (work_end - work_start).total_seconds()
+    total_hours = round(total_seconds / 3600, 2)
+
+    year_start = jdatetime.date(jy, 1, 1).togregorian()
+    year_end = jdatetime.date(jy, 12, jdatetime.j_days_in_month[11]).togregorian()
+    approved_leaves = LeaveRequest.objects.filter(
+        user=u, status="approved", start_date__gte=year_start, end_date__lte=year_end
+    )
+    used_days = 0
+    for lr in approved_leaves:
+        used_days += (lr.end_date - lr.start_date).days + 1
+    remaining_leave = max(0, 26 - used_days)
+
+    monthly_stats = {
+        "total_hours": total_hours,
+        "tardy_minutes": tardy_minutes,
+        "absent_days": absent_days,
+        "remaining_leave": remaining_leave,
+    }
+
+    context = {
+        "user": u,
+        "today_status": status_info,
+        "notifications": notifications,
+        "monthly_stats": monthly_stats,
+    }
+    return render(request, "core/user_profile.html", context)
 
 
 def my_logs(request):

--- a/static/core/global.css
+++ b/static/core/global.css
@@ -270,20 +270,72 @@ label {
   border: 3px solid #fff;
   margin-bottom: 0.6rem;
 }
-.profile-details {
+.profile-banner .profile-codes {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.status-widget {
+  text-align: center;
+}
+.status-widget .status {
+  padding: 1rem;
+  border-radius: var(--radius);
+}
+.status-widget .present {
+  background: #e8f5e9;
+  color: #2e7d32;
+}
+.status-widget .absent {
+  background: #ffebee;
+  color: #c62828;
+}
+.status-widget .leave {
+  background: #e3f2fd;
+  color: #1565c0;
+}
+.status-widget .holiday {
+  background: #f5f5f5;
+  color: #616161;
+}
+
+.notifications-widget ul {
   list-style: none;
   padding: 0;
-  margin: 1rem 0;
+  margin: 0;
 }
-.profile-details li {
+.notifications-widget li {
   margin-bottom: 0.4rem;
 }
-.profile-actions {
-  margin-top: 1.5rem;
+
+.stats-widget .stats-grid {
+  display: flex;
+  flex-wrap: wrap;
+  text-align: center;
+}
+.stats-widget .stat-card {
+  flex: 1 1 150px;
+  padding: 1rem;
+}
+.stats-widget .stat-card i {
+  display: block;
+  font-size: 1.4rem;
+  margin-bottom: 0.4rem;
+}
+.stats-widget .stat-card .value {
+  display: block;
+  font-weight: bold;
+  font-size: 1.2rem;
+}
+
+.quick-actions .actions {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
-  justify-content: center;
+}
+.quick-actions .actions .btn {
+  flex: 1 1 200px;
+  text-align: center;
 }
 
 /* general page wrapper for centering card layouts */

--- a/templates/core/user_profile.html
+++ b/templates/core/user_profile.html
@@ -2,22 +2,68 @@
 {% load static %}
 {% block title %}پروفایل کاربر{% endblock %}
 {% block content %}
-<div class="card page page-md profile-card fade-in">
-  <div class="profile-banner">
-    <img class="profile-avatar" src="{% if user.face_image %}{{ user.face_image.url }}{% else %}{% static 'core/avatar.png' %}{% endif %}" alt="{{ user.get_full_name }}">
-    <h2 class="page-title">
-      <i class="fa fa-user"></i>
-      پروفایل {{ user.get_full_name }}
-    </h2>
+<div class="page page-md fade-in profile-page">
+  <div class="card profile-card">
+    <div class="profile-banner">
+      <img class="profile-avatar" src="{% if user.face_image %}{{ user.face_image.url }}{% else %}{% static 'core/avatar.png' %}{% endif %}" alt="{{ user.get_full_name }}">
+      <h2 class="page-title"><i class="fa fa-user"></i> پروفایل {{ user.get_full_name }}</h2>
+      <p class="profile-codes">کد پرسنلی: {{ user.personnel_code }} | کد ملی: {{ user.national_id }}</p>
+    </div>
   </div>
-  <ul class="profile-details">
-    <li>کد پرسنلی: {{ user.personnel_code }}</li>
-    <li>کد ملی: {{ user.national_id }}</li>
-  </ul>
-  <div class="profile-actions">
-    <a class="btn" href="{% url 'my_logs' %}"><i class="fa fa-list-alt" style="margin-left:0.4rem;"></i> مشاهده ترددها</a>
-    <a class="btn" href="{% url 'user_leave_requests' %}"><i class="fa fa-calendar" style="margin-left:0.4rem;"></i> مرخصی‌های من</a>
-    <a class="btn" href="{% url 'user_inquiry' %}"><i class="fas fa-chevron-right" style="margin-left:0.4rem;"></i> خروج</a>
+
+  <div class="card status-widget">
+    <h3 class="section-title"><i class="fas fa-calendar-day"></i> وضعیت امروز شما</h3>
+    <div class="status {{ today_status.color }}">
+      <span class="label">{{ today_status.label }}</span>
+      {% if today_status.detail %}<span class="detail">اولین ورود: {{ today_status.detail }}</span>{% endif %}
+    </div>
+  </div>
+
+  <div class="card notifications-widget">
+    <h3 class="section-title"><i class="fas fa-bell"></i> آخرین اعلان‌ها و درخواست‌ها</h3>
+    <ul class="notification-list">
+      {% for n in notifications %}
+        <li>{{ n }}</li>
+      {% empty %}
+        <li>اعلانی وجود ندارد.</li>
+      {% endfor %}
+    </ul>
+  </div>
+
+  <div class="card stats-widget">
+    <h3 class="section-title"><i class="fas fa-chart-line"></i> آمار عملکرد من در این ماه</h3>
+    <div class="stats-grid">
+      <div class="stat-card">
+        <i class="fas fa-clock"></i>
+        <span class="value">{{ monthly_stats.total_hours }}</span>
+        <span class="label">ساعات کاری</span>
+      </div>
+      <div class="stat-card">
+        <i class="fas fa-hourglass-half"></i>
+        <span class="value">{{ monthly_stats.tardy_minutes }}</span>
+        <span class="label">دقایق تأخیر</span>
+      </div>
+      <div class="stat-card">
+        <i class="fas fa-user-times"></i>
+        <span class="value">{{ monthly_stats.absent_days }}</span>
+        <span class="label">روزهای غیبت</span>
+      </div>
+      <div class="stat-card">
+        <i class="fas fa-plane"></i>
+        <span class="value">{{ monthly_stats.remaining_leave }}</span>
+        <span class="label">باقی‌مانده مرخصی</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="card quick-actions">
+    <h3 class="section-title"><i class="fas fa-bolt"></i> دسترسی سریع</h3>
+    <div class="actions">
+      <a class="btn" href="{% url 'my_logs' %}"><i class="fa fa-list-alt" style="margin-left:0.4rem;"></i> مشاهده گزارش کامل تردد</a>
+      <a class="btn" href="{% url 'leave_request' %}"><i class="fa fa-plus" style="margin-left:0.4rem;"></i> ثبت درخواست جدید</a>
+      <a class="btn" href="{% url 'user_leave_requests' %}"><i class="fa fa-tasks" style="margin-left:0.4rem;"></i> پیگیری درخواست‌های من</a>
+      <a class="btn" href="{% url 'user_inquiry' %}"><i class="fas fa-chevron-right" style="margin-left:0.4rem;"></i> بازگشت</a>
+    </div>
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- redesign user profile page with integrated codes, status widget, notifications, monthly stats, and quick action buttons
- style additions for new widgets in global.css
- compute user status, recent notifications, and monthly performance stats in view

## Testing
- `python manage.py test`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_689671e90cf48333adf0a7069ce0ef1e