### PR TITLE
Integrate JalaliDatePicker for date and time inputs

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -1,7 +1,6 @@
 from django import forms
 from django.contrib.auth import get_user_model
 from django_jalali import forms as jforms
-from django_jalali.admin.widgets import AdminjDateWidget
 import jdatetime
 from attendance import models as attendance_models
 from attendance.models import (
@@ -15,6 +14,26 @@ from attendance.models import (
 )
 
 User = get_user_model()
+
+
+class JalaliDateInput(forms.TextInput):
+    """Widget for JalaliDatePicker date inputs."""
+
+    def __init__(self, attrs=None):
+        base_attrs = {"data-jdp": "", "data-jdp-only-date": ""}
+        if attrs:
+            base_attrs.update(attrs)
+        super().__init__(attrs=base_attrs)
+
+
+class JalaliTimeInput(forms.TextInput):
+    """Widget for JalaliDatePicker time inputs."""
+
+    def __init__(self, attrs=None):
+        base_attrs = {"data-jdp": "", "data-jdp-only-time": ""}
+        if attrs:
+            base_attrs.update(attrs)
+        super().__init__(attrs=base_attrs)
 
 class InquiryForm(forms.Form):
     personnel_code = forms.CharField(label="کد پرسنلی", max_length=20)
@@ -37,12 +56,9 @@ class CustomUserSimpleForm(forms.ModelForm):
 
 
 class EditRequestForm(forms.ModelForm):
-    date = jforms.jDateField(label="تاریخ", widget=AdminjDateWidget())
+    date = jforms.jDateField(label="تاریخ", widget=JalaliDateInput())
     log_type = forms.ChoiceField(choices=LOG_TYPE_CHOICES, label="نوع تردد")
-    time = forms.TimeField(
-        label="ساعت",
-        widget=forms.TimeInput(format="%H:%M", attrs={"type": "time", "step": 60}),
-    )
+    time = forms.TimeField(label="ساعت", widget=JalaliTimeInput())
 
     class Meta:
         model = EditRequest
@@ -100,7 +116,7 @@ class EditRequestForm(forms.ModelForm):
 
 
 class LeaveRequestForm(forms.ModelForm):
-    start_date = jforms.jDateField(label="از تاریخ", widget=AdminjDateWidget())
+    start_date = jforms.jDateField(label="از تاریخ", widget=JalaliDateInput())
     duration = forms.IntegerField(label="مدت (روز)", min_value=1)
     leave_type = forms.ModelChoiceField(
         queryset=attendance_models.LeaveType.objects.all(),
@@ -155,11 +171,8 @@ class ManualLogForm(forms.Form):
     """Form for admins to directly register an attendance log for a user."""
 
     user = forms.ModelChoiceField(queryset=User.objects.all(), label="کاربر")
-    date = jforms.jDateField(label="تاریخ", widget=AdminjDateWidget())
-    time = forms.TimeField(
-        label="ساعت",
-        widget=forms.TimeInput(format="%H:%M", attrs={"type": "time", "step": 60}),
-    )
+    date = jforms.jDateField(label="تاریخ", widget=JalaliDateInput())
+    time = forms.TimeField(label="ساعت", widget=JalaliTimeInput())
     log_type = forms.ChoiceField(choices=LOG_TYPE_CHOICES, label="نوع تردد")
 
     def clean(self):
@@ -195,8 +208,8 @@ class ManualLeaveForm(forms.ModelForm):
     """Form for admins to directly register a leave for a user."""
 
     user = forms.ModelChoiceField(queryset=User.objects.all(), label="کاربر")
-    start_date = jforms.jDateField(label="از تاریخ", widget=AdminjDateWidget())
-    end_date = jforms.jDateField(label="تا تاریخ", widget=AdminjDateWidget())
+    start_date = jforms.jDateField(label="از تاریخ", widget=JalaliDateInput())
+    end_date = jforms.jDateField(label="تا تاریخ", widget=JalaliDateInput())
 
     leave_type = forms.ModelChoiceField(
         queryset=attendance_models.LeaveType.objects.all(),
@@ -240,14 +253,14 @@ class AttendanceStatusForm(forms.Form):
     """Simple form to pick a Jalali date for attendance status."""
     date = jforms.jDateField(
         label="تاریخ",
-        widget=AdminjDateWidget(),
+        widget=JalaliDateInput(),
         required=False,
     )
 
 
 class UserLogsRangeForm(forms.Form):
-    start = jforms.jDateField(label="از تاریخ", widget=AdminjDateWidget())
-    end = jforms.jDateField(label="تا تاریخ", widget=AdminjDateWidget())
+    start = jforms.jDateField(label="از تاریخ", widget=JalaliDateInput())
+    end = jforms.jDateField(label="تا تاریخ", widget=JalaliDateInput())
 
     def clean(self):
         cleaned = super().clean()
@@ -289,8 +302,8 @@ class ShiftForm(forms.ModelForm):
             "end_time": "پایان",
         }
         widgets = {
-            "start_time": forms.TimeInput(format="%H:%M", attrs={"type": "time"}),
-            "end_time": forms.TimeInput(format="%H:%M", attrs={"type": "time"}),
+            "start_time": JalaliTimeInput(),
+            "end_time": JalaliTimeInput(),
         }
 
 
@@ -314,7 +327,7 @@ class LeaveTypeForm(forms.ModelForm):
 class ReportFilterForm(forms.Form):
     start_date = jforms.jDateField(
         label="از تاریخ",
-        widget=AdminjDateWidget(
+        widget=JalaliDateInput(
             attrs={
                 "placeholder": "۱۴۰۳/۰۵/۱۰",
                 "class": "date-input vjDateField",
@@ -325,7 +338,7 @@ class ReportFilterForm(forms.Form):
     )
     end_date = jforms.jDateField(
         label="تا تاریخ",
-        widget=AdminjDateWidget(
+        widget=JalaliDateInput(
             attrs={
                 "placeholder": "۱۴۰۳/۰۵/۱۰",
                 "class": "date-input vjDateField",

--- a/static/core/global.js
+++ b/static/core/global.js
@@ -49,4 +49,8 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   }
 
+  if (window.jalaliDatepicker) {
+    jalaliDatepicker.startWatch({time:true, hasSecond:false});
+  }
+
 });

--- a/templates/core/admin_user_profile.html
+++ b/templates/core/admin_user_profile.html
@@ -66,8 +66,7 @@
 </div>
 {% endblock %}
 
-{% block extra_js %}
-{{ requests_form.media }}
+  {% block extra_js %}
 <script>
 document.querySelectorAll('.tab-link').forEach(link => {
   link.addEventListener('click', function(e){

--- a/templates/core/attendance_status.html
+++ b/templates/core/attendance_status.html
@@ -48,7 +48,6 @@
 </div>
 {% endblock %}
 {% block extra_js %}
-{{ form.media }}
 {% if realtime %}
 <script>
 function refreshStatus(){

--- a/templates/core/base.html
+++ b/templates/core/base.html
@@ -9,6 +9,7 @@
   <link rel="stylesheet" href="{% static 'fonts/vazir.ttf' %}" as="font" type="font/ttf" crossorigin />
   <!-- Font Awesome -->
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" />
+  <link rel="stylesheet" href="https://unpkg.com/@majidh1/jalalidatepicker/dist/jalalidatepicker.min.css" />
   {% block extra_css %}{% endblock %}
 </head>
 <body>
@@ -29,6 +30,7 @@
   </main>
   <footer class="site-footer">
   </footer>
+  <script src="https://unpkg.com/@majidh1/jalalidatepicker/dist/jalalidatepicker.min.js" defer></script>
   <script src="{% static 'core/global.js' %}" defer></script>
   {% if messages %}
   <script>

--- a/templates/core/base_device.html
+++ b/templates/core/base_device.html
@@ -9,10 +9,12 @@
   <link rel="stylesheet" href="{% static 'fonts/vazir.ttf' %}" as="font" type="font/ttf" crossorigin />
   <link rel="stylesheet" href="{% static 'core/device_full.css' %}" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" />
+  <link rel="stylesheet" href="https://unpkg.com/@majidh1/jalalidatepicker/dist/jalalidatepicker.min.css" />
   {% block extra_css %}{% endblock %}
 </head>
 <body>
   {% block content %}{% endblock %}
+  <script src="https://unpkg.com/@majidh1/jalalidatepicker/dist/jalalidatepicker.min.js" defer></script>
   <script src="{% static 'core/global.js' %}" defer></script>
   {% block extra_js %}{% endblock %}
 </body>

--- a/templates/core/edit_request_form.html
+++ b/templates/core/edit_request_form.html
@@ -28,4 +28,4 @@
   </form>
 </div>
 {% endblock %}
-{% block extra_js %}{{ form.media }}{% endblock %}
+{% block extra_js %}{% endblock %}

--- a/templates/core/leave_request_form.html
+++ b/templates/core/leave_request_form.html
@@ -28,4 +28,4 @@
   </form>
 </div>
 {% endblock %}
-{% block extra_js %}{{ form.media }}{% endblock %}
+{% block extra_js %}{% endblock %}

--- a/templates/core/manual_leave_form.html
+++ b/templates/core/manual_leave_form.html
@@ -23,4 +23,4 @@
   <a href="{% url 'leave_requests' %}" class="btn" style="background:var(--color-muted);color:#fff;">لغو</a>
 </form>
 {% endblock %}
-{% block extra_js %}{{ form.media }}{% endblock %}
+{% block extra_js %}{% endblock %}

--- a/templates/core/manual_log_form.html
+++ b/templates/core/manual_log_form.html
@@ -22,5 +22,5 @@
   </div>
 </form>
 {% endblock %}
-{% block extra_js %}{{ form.media }}{% endblock %}
+{% block extra_js %}{% endblock %}
 

--- a/templates/core/user_logs_admin.html
+++ b/templates/core/user_logs_admin.html
@@ -25,4 +25,4 @@
   </tbody>
 </table>
 {% endblock %}
-{% block extra_js %}{{ form.media }}{% endblock %}
+{% block extra_js %}{% endblock %}

--- a/templates/core/user_reports.html
+++ b/templates/core/user_reports.html
@@ -94,7 +94,6 @@
 {% endblock %}
 
 {% block extra_js %}
-{{ form.media }}
 <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
 <script>
   $(function() {


### PR DESCRIPTION
## Summary
- add reusable JalaliDatePicker widgets for date and time fields
- load JalaliDatePicker assets globally and initialize watcher
- remove legacy per-form widget scripts

## Testing
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_6899eece549c8333ac90572ac038c048