### PR TITLE
Mirror camera feed, rename users to employees, fix leave request submission

### DIFF
--- a/attendance/models.py
+++ b/attendance/models.py
@@ -8,7 +8,7 @@ LOG_TYPE_CHOICES = [
 ]
 
 SOURCE_CHOICES = [
-    ("self", "کاربر"),
+    ("self", "کارمند"),
     ("auto", "سیستم"),
     ("manager", "مدیر"),
 ]

--- a/core/forms.py
+++ b/core/forms.py
@@ -170,7 +170,7 @@ class LeaveRequestForm(forms.ModelForm):
 class ManualLogForm(forms.Form):
     """Form for admins to directly register an attendance log for a user."""
 
-    user = forms.ModelChoiceField(queryset=User.objects.all(), label="کاربر")
+    user = forms.ModelChoiceField(queryset=User.objects.all(), label="کارمند")
     date = jforms.jDateField(label="تاریخ", widget=JalaliDateInput())
     time = forms.TimeField(label="ساعت", widget=JalaliTimeInput())
     log_type = forms.ChoiceField(choices=LOG_TYPE_CHOICES, label="نوع تردد")
@@ -207,7 +207,7 @@ class ManualLogForm(forms.Form):
 class ManualLeaveForm(forms.ModelForm):
     """Form for admins to directly register a leave for a user."""
 
-    user = forms.ModelChoiceField(queryset=User.objects.all(), label="کاربر")
+    user = forms.ModelChoiceField(queryset=User.objects.all(), label="کارمند")
     start_date = jforms.jDateField(label="از تاریخ", widget=JalaliDateInput())
     end_date = jforms.jDateField(label="تا تاریخ", widget=JalaliDateInput())
 
@@ -361,7 +361,7 @@ class ReportFilterForm(forms.Form):
     )
     users = forms.ModelMultipleChoiceField(
         queryset=User.objects.all(),
-        label="کاربران",
+        label="کارکنان",
         required=False,
         widget=forms.SelectMultiple(attrs={"class": "multi-select"}),
     )
@@ -374,7 +374,7 @@ class ReportFilterForm(forms.Form):
 
 
 class MonthlyPerformanceForm(forms.Form):
-    user = forms.ModelChoiceField(queryset=User.objects.all(), label="کاربر")
+    user = forms.ModelChoiceField(queryset=User.objects.all(), label="کارمند")
     year = forms.IntegerField(label="سال", initial=jdatetime.date.today().year)
     MONTH_CHOICES = [
         (1, "فروردین"),

--- a/core/urls.py
+++ b/core/urls.py
@@ -32,7 +32,7 @@ urlpatterns = [
     path("api/verify-face/",        views.api_verify_face,                name="api_verify_face"),
     path("api/register-face/",      views.api_register_face,              name="api_register_face"),
 
-    # —————— کاربر عادی ——————
+    # —————— کارمند عادی ——————
     path("user/inquiry/",           views.user_inquiry,                   name="user_inquiry"),
     path("user/profile/",           views.user_profile,                  name="user_profile"),
     path("user/edit-request/",     views.edit_request,                  name="edit_request"),
@@ -45,7 +45,7 @@ urlpatterns = [
     path("management/face-check/",     views.management_face_check,     name="management_face_check"),
     path("management/face-check/api/", views.api_management_verify_face, name="api_management_verify_face"),
 
-    # مدیریت CRUD کاربران
+    # مدیریت CRUD کارکنان
     path("management/users/",                views.management_users,               name="management_users"),
     path("management/users/add/",            views.user_add,                       name="user_add"),
     path("management/users/<int:pk>/edit/",  views.user_update,                    name="user_update"),

--- a/core/views.py
+++ b/core/views.py
@@ -145,7 +145,7 @@ def device_face_check(request):
 
 @login_required
 def device_page(request):
-    """صفحهٔ اصلی کیوسک برای ثبت تردد کاربران عادی"""
+    """صفحهٔ اصلی کیوسک برای ثبت تردد کارکنان عادی"""
     return render(request, "core/device.html")
 
 
@@ -260,7 +260,7 @@ def api_verify_face(request):
 @require_POST
 @login_required
 def api_register_face(request):
-    """ثبت چهرهٔ کاربر با بررسی حرکت ساده برای جلوگیری از تقلب."""
+    """ثبت چهرهٔ کارمند با بررسی حرکت ساده برای جلوگیری از تقلب."""
     img1 = request.POST.get("image1")
     img2 = request.POST.get("image2")
     if img1 and img2:
@@ -296,7 +296,7 @@ def api_register_face(request):
     request.user.save()
     return JsonResponse({"ok": True, "redirect": reverse("management_dashboard")})
 # —————————————————————————
-# مشاهده تردد کاربر عادی
+# مشاهده تردد کارمند عادی
 # —————————————————————————
 
 def user_inquiry(request):
@@ -531,7 +531,7 @@ def cancel_leave_request(request, pk):
 
 
 # —————————————————————————
-# پنل مدیریت کاربران
+# پنل مدیریت کارکنان
 # —————————————————————————
 
 staff_required = user_passes_test(lambda u: u.is_staff)
@@ -596,20 +596,20 @@ def management_users(request):
             qs = User.objects.filter(id__in=selected_ids)
             if action == "deactivate":
                 qs.update(is_active=False)
-                messages.success(request, "کاربران انتخاب‌شده غیرفعال شدند.")
+                messages.success(request, "کارکنان انتخاب‌شده غیرفعال شدند.")
             elif action == "assign_group":
                 group_id = request.POST.get("group")
                 if group_id:
                     qs.update(group_id=group_id)
-                    messages.success(request, "گروه کاربران به‌روزرسانی شد.")
+                    messages.success(request, "گروه کارکنان به‌روزرسانی شد.")
             elif action == "assign_shift":
                 shift_id = request.POST.get("shift")
                 if shift_id:
                     qs.update(shift_id=shift_id)
-                    messages.success(request, "شیفت کاربران به‌روزرسانی شد.")
+                    messages.success(request, "شیفت کارکنان به‌روزرسانی شد.")
             elif action == "delete":
                 qs.delete()
-                messages.success(request, "کاربران انتخاب‌شده حذف شدند.")
+                messages.success(request, "کارکنان انتخاب‌شده حذف شدند.")
         return redirect("management_users")
 
     users = User.objects.all().select_related("group", "shift")
@@ -658,11 +658,11 @@ def user_add(request):
             # ست پسورد تصادفی قوی (غیرقابل حدس)
             user.set_password(secrets.token_urlsafe(16))
             user.save()
-            messages.success(request, "کاربر جدید اضافه شد.")
+            messages.success(request, "کارمند جدید اضافه شد.")
             return redirect("register_face_page_for_user", user_id=user.pk)
     else:
         form = CustomUserSimpleForm()
-    return render(request, "core/user_form.html", {"form": form, "title": "افزودن کاربر جدید"})
+    return render(request, "core/user_form.html", {"form": form, "title": "افزودن کارمند جدید"})
 
 @login_required
 @staff_required
@@ -672,11 +672,11 @@ def user_update(request, pk):
         form = CustomUserSimpleForm(request.POST, request.FILES, instance=obj)
         if form.is_valid():
             form.save()
-            messages.success(request, "کاربر ویرایش شد.")
+            messages.success(request, "کارمند ویرایش شد.")
             return redirect("management_users")
     else:
         form = CustomUserSimpleForm(instance=obj)
-    return render(request, "core/user_form.html", {"form": form, "title": "ویرایش کاربر"})
+    return render(request, "core/user_form.html", {"form": form, "title": "ویرایش کارمند"})
 
 @login_required
 @staff_required
@@ -703,7 +703,7 @@ def admin_user_profile(request, pk):
         form = CustomUserSimpleForm(request.POST, request.FILES, instance=user_obj)
         if form.is_valid():
             form.save()
-            messages.success(request, "اطلاعات کاربر به‌روز شد.")
+            messages.success(request, "اطلاعات کارمند به‌روز شد.")
             return redirect("admin_user_profile", pk=pk)
     else:
         form = CustomUserSimpleForm(instance=user_obj)
@@ -745,7 +745,7 @@ def user_face_delete(request, pk):
         user_obj.face_image.delete(save=False)
     user_obj.face_image = None
     user_obj.save()
-    messages.success(request, "چهره کاربر حذف شد.")
+    messages.success(request, "چهره کارمند حذف شد.")
     return redirect("admin_user_profile", pk=pk)
 
 @login_required
@@ -959,7 +959,7 @@ def management_dashboard(request):
     return render(request, 'core/management_dashboard.html', context)
 
 
-# ======= گزارش‌گیری کاربران =======
+# ======= گزارش‌گیری کارکنان =======
 @login_required
 @staff_required
 def user_reports(request):

--- a/static/core/device.css
+++ b/static/core/device.css
@@ -36,6 +36,7 @@
   border-radius: var(--radius);
   background: #111;
   direction: ltr;
+  transform: scaleX(-1);
 }
 #device-overlay {
   position: absolute;
@@ -106,7 +107,7 @@
     aspect-ratio: 4/3;
     padding: 0 !important;
   }
-  .device-video-area video,
+.device-video-area video,
 .device-video-area canvas {
   width: 100% !important;
   max-width: 100vw !important;
@@ -117,6 +118,7 @@
   border-radius: 10px;
   display: block;
   margin: 0 auto;
+  transform: scaleX(-1);
 }
 
   .device-message {

--- a/static/core/device.js
+++ b/static/core/device.js
@@ -42,7 +42,10 @@ document.addEventListener('DOMContentLoaded', () => {
   function capture() {
     canvas.width = video.videoWidth;
     canvas.height = video.videoHeight;
-    ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+    ctx.save();
+    ctx.scale(-1, 1);
+    ctx.drawImage(video, -canvas.width, 0, canvas.width, canvas.height);
+    ctx.restore();
     return canvas.toDataURL('image/jpeg');
   }
 
@@ -64,7 +67,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
     canvas.width = video.videoWidth;
     canvas.height = video.videoHeight;
-    ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+    ctx.save();
+    ctx.scale(-1, 1);
+    ctx.drawImage(video, -canvas.width, 0, canvas.width, canvas.height);
+    ctx.restore();
 
     let brightness = 0;
     try {

--- a/static/core/global.css
+++ b/static/core/global.css
@@ -556,6 +556,7 @@ label {
   object-fit: contain;
   background: #000;
   direction: ltr;
+  transform: scaleX(-1);
 }
 
 .action-btn {

--- a/templates/core/_user_form_fields.html
+++ b/templates/core/_user_form_fields.html
@@ -14,7 +14,7 @@
   {% endfor %}
   <div class="profile-actions" style="grid-column:1/-1;">
     <button type="submit" class="btn">
-      {% if form.instance.pk %}ذخیره تغییرات{% else %}ایجاد کاربر{% endif %}
+      {% if form.instance.pk %}ذخیره تغییرات{% else %}ایجاد کارمند{% endif %}
     </button>
     <a href="{% if cancel_url %}{{ cancel_url }}{% else %}{% url 'management_users' %}{% endif %}" class="btn" style="background:var(--color-muted);color:#fff;">لغو</a>
   </div>

--- a/templates/core/base_management.html
+++ b/templates/core/base_management.html
@@ -16,12 +16,12 @@
         <i class="fas fa-user-check"></i> وضعیت حضور
       </a>
       <a href="{% url 'management_users' %}" class="{% if request.resolver_match.url_name == 'management_users' %}active{% endif %}">
-        <i class="fas fa-users"></i> کاربران
+        <i class="fas fa-users"></i> کارکنان
       </a>
       <details class="sidebar-group {% if request.resolver_match.url_name == 'management_reports' or request.resolver_match.url_name == 'monthly_profile' %}open{% endif %}">
         <summary><i class="fas fa-file-alt"></i> گزارش‌ها</summary>
         <nav class="sub-menu">
-          <a href="{% url 'management_reports' %}" class="{% if request.resolver_match.url_name == 'management_reports' %}active{% endif %}">گزارش کاربران</a>
+          <a href="{% url 'management_reports' %}" class="{% if request.resolver_match.url_name == 'management_reports' %}active{% endif %}">گزارش کارکنان</a>
           <a href="{% url 'monthly_profile' %}" class="{% if request.resolver_match.url_name == 'monthly_profile' %}active{% endif %}">پروفایل ماهانه</a>
         </nav>
       </details>

--- a/templates/core/device_face_check.html
+++ b/templates/core/device_face_check.html
@@ -6,6 +6,7 @@
 document.addEventListener('DOMContentLoaded', () => {
   const video = document.getElementById('video');
   const canvas = document.getElementById('canvas');
+  const ctx = canvas.getContext('2d');
   const btn = document.getElementById('verifyBtn');
   const message = document.getElementById('verifyResult');
 
@@ -28,7 +29,10 @@ document.addEventListener('DOMContentLoaded', () => {
     btn.disabled = true;
     canvas.width = video.videoWidth;
     canvas.height = video.videoHeight;
-    canvas.getContext('2d').drawImage(video, 0, 0, canvas.width, canvas.height);
+    ctx.save();
+    ctx.scale(-1, 1);
+    ctx.drawImage(video, -canvas.width, 0, canvas.width, canvas.height);
+    ctx.restore();
     const dataUrl = canvas.toDataURL('image/jpeg');
     message.textContent = 'لطفاً صبر کنید...';
     fetch("{% url 'api_device_verify_face' %}", {

--- a/templates/core/edit_requests.html
+++ b/templates/core/edit_requests.html
@@ -27,7 +27,7 @@
 <div class="request-cards mobile-only">
   {% for r in requests %}
   <div class="request-card fade-in">
-    <div class="row"><span class="label">کاربر:</span><span>{{ r.user.get_full_name }} - {{ r.user.personnel_code }}</span></div>
+    <div class="row"><span class="label">کارمند:</span><span>{{ r.user.get_full_name }} - {{ r.user.personnel_code }}</span></div>
     <div class="row"><span class="label">زمان:</span><span>{{ r.timestamp|jformat:"%Y/%m/%d %H:%M" }}</span></div>
     <div class="row"><span class="label">نوع:</span><span>{% if r.log_type == 'in' %}ورود{% else %}خروج{% endif %}</span></div>
     <div class="row"><span class="label">توضیح:</span><span>{{ r.note|default:"-" }}</span></div>
@@ -58,7 +58,7 @@
 <table class="management-table">
   <thead>
     <tr>
-      <th>کاربر</th>
+      <th>کارمند</th>
       <th>زمان</th>
       <th>نوع</th>
       <th>توضیح</th>

--- a/templates/core/group_list.html
+++ b/templates/core/group_list.html
@@ -8,7 +8,7 @@
 <div class="table-responsive">
 <table class="management-table">
   <thead>
-    <tr><th>نام</th><th>تعداد کاربران</th><th>شیفت</th><th>عملیات</th></tr>
+    <tr><th>نام</th><th>تعداد کارکنان</th><th>شیفت</th><th>عملیات</th></tr>
   </thead>
   <tbody>
   {% for g in groups %}
@@ -55,7 +55,7 @@ document.querySelectorAll('.delete-item').forEach(btn => {
     const affected = this.dataset.affected;
     let msg = `آیا از حذف ${name} مطمئن هستید؟`;
     if(affected && parseInt(affected) > 0){
-      msg = `حذف ${name} بر روی ${affected} کاربر تأثیر خواهد گذاشت. آیا مطمئن هستید؟`;
+      msg = `حذف ${name} بر روی ${affected} کارمند تأثیر خواهد گذاشت. آیا مطمئن هستید؟`;
     }
     deleteMsg.textContent = msg;
     deleteForm.action = this.dataset.url;

--- a/templates/core/leave_request_confirm.html
+++ b/templates/core/leave_request_confirm.html
@@ -11,7 +11,9 @@
   {% endif %}
   <form method="post">
     {% csrf_token %}
-    {% for f in form.hidden_fields %}{{ f }}{% endfor %}
+    {% for field in form %}
+      <input type="hidden" name="{{ field.html_name }}" value="{{ field.value|default_if_none:'' }}">
+    {% endfor %}
     <input type="hidden" name="confirm" value="1">
     <button class="btn" type="submit">ثبت</button>
   </form>

--- a/templates/core/leave_requests.html
+++ b/templates/core/leave_requests.html
@@ -27,7 +27,7 @@
 <div class="request-cards mobile-only">
   {% for r in requests %}
   <div class="request-card fade-in">
-    <div class="row"><span class="label">کاربر:</span><span>{{ r.user.get_full_name }} - {{ r.user.personnel_code }}</span></div>
+    <div class="row"><span class="label">کارمند:</span><span>{{ r.user.get_full_name }} - {{ r.user.personnel_code }}</span></div>
     <div class="row"><span class="label">از:</span><span>{{ r.start_date|jformat:"%Y/%m/%d" }}</span></div>
     <div class="row"><span class="label">تا:</span><span>{{ r.end_date|jformat:"%Y/%m/%d" }}</span></div>
     {% if r.leave_type %}<div class="row"><span class="label">نوع:</span><span>{{ r.leave_type }}</span></div>{% endif %}
@@ -74,7 +74,7 @@
 <table class="management-table">
   <thead>
     <tr>
-      <th>کاربر</th>
+      <th>کارمند</th>
       <th>از</th>
       <th>تا</th>
       <th>نوع</th>

--- a/templates/core/management_dashboard.html
+++ b/templates/core/management_dashboard.html
@@ -91,7 +91,7 @@
   <div class="request-cards mobile-only">
     {% for r in pending_actions %}
     <div class="request-card fade-in">
-      <div class="row"><span class="label">کاربر:</span><span>{{ r.user.get_full_name }}</span></div>
+      <div class="row"><span class="label">کارمند:</span><span>{{ r.user.get_full_name }}</span></div>
       <div class="row"><span class="label">تاریخ:</span><span>{{ r.date }}</span></div>
       <div class="row"><span class="label">نوع:</span><span>{{ r.type_label }}</span></div>
       <div class="actions">
@@ -118,7 +118,7 @@
   <div class="table-responsive desktop-only">
     <table class="management-table">
       <thead>
-        <tr><th>کاربر</th><th>تاریخ</th><th>نوع</th><th>اقدام</th></tr>
+        <tr><th>کارمند</th><th>تاریخ</th><th>نوع</th><th>اقدام</th></tr>
       </thead>
       <tbody>
         {% for r in pending_actions %}
@@ -156,7 +156,7 @@
   <div class="performance-wrapper">
     <div class="performance-box">
       <h4>بدها <span class="info-icon" data-target="bad-info"><i class="fas fa-info-circle"></i></span></h4>
-      <div id="bad-info" class="info-text">کاربرانی با بیشترین روزهای دیرکرد در ماه اخیر</div>
+      <div id="bad-info" class="info-text">کارکنانی با بیشترین روزهای دیرکرد در ماه اخیر</div>
       <table class="performance-table">
         <thead><tr><th>نام</th><th>تعداد</th></tr></thead>
         <tbody>
@@ -170,7 +170,7 @@
     </div>
     <div class="performance-box">
       <h4>خوب‌ها <span class="info-icon" data-target="good-info"><i class="fas fa-info-circle"></i></span></h4>
-      <div id="good-info" class="info-text">کاربرانی با بیشترین روز بدون تأخیر متوالی</div>
+      <div id="good-info" class="info-text">کارکنانی با بیشترین روز بدون تأخیر متوالی</div>
       <table class="performance-table">
         <thead><tr><th>نام</th><th>تعداد</th></tr></thead>
         <tbody>

--- a/templates/core/management_face_check.html
+++ b/templates/core/management_face_check.html
@@ -6,6 +6,7 @@
 document.addEventListener('DOMContentLoaded', () => {
   const video = document.getElementById('video');
   const canvas = document.getElementById('canvas');
+  const ctx = canvas.getContext('2d');
   const btn = document.getElementById('verifyBtn');
   const msgEl = document.getElementById('verifyResult');
 
@@ -28,7 +29,10 @@ document.addEventListener('DOMContentLoaded', () => {
     btn.disabled = true;
     canvas.width = video.videoWidth;
     canvas.height = video.videoHeight;
-    canvas.getContext('2d').drawImage(video, 0, 0);
+    ctx.save();
+    ctx.scale(-1, 1);
+    ctx.drawImage(video, -canvas.width, 0, canvas.width, canvas.height);
+    ctx.restore();
     const dataUrl = canvas.toDataURL('image/png');
 
     msgEl.textContent = 'لطفاً صبر کنید...';

--- a/templates/core/management_users.html
+++ b/templates/core/management_users.html
@@ -1,12 +1,12 @@
 {% extends "core/base_management.html" %}
-{% block title %}مدیریت کاربران{% endblock %}
+{% block title %}مدیریت کارکنان{% endblock %}
 {% block management_content %}
 <h2 class="page-title">
   <i class="fas fa-users-cog"></i>
-  مدیریت کاربران
+  مدیریت کارکنان
 </h2>
 <a class="btn" href="{% url 'user_add' %}" style="margin-bottom:1.4rem;">
-  <i class="fas fa-user-plus" style="margin-left:0.5rem;"></i> افزودن کاربر جدید
+  <i class="fas fa-user-plus" style="margin-left:0.5rem;"></i> افزودن کارمند جدید
 </a>
 
 <form method="get" class="filter-panel" style="margin-bottom:1rem;">
@@ -108,7 +108,7 @@
 
 <div id="delete-modal" class="modal">
   <div class="modal-content">
-    <p>آیا از حذف کاربر مطمئن هستید؟</p>
+    <p>آیا از حذف کارمند مطمئن هستید؟</p>
     <form method="post" id="delete-form">
       {% csrf_token %}
       <button type="submit" class="btn btn-danger">حذف</button>
@@ -132,7 +132,7 @@ const bulkForm = document.getElementById('bulk-form');
 if(bulkForm){
   bulkForm.addEventListener('submit', function(e){
     if(document.getElementById('bulk-action-select').value === 'delete'){
-      if(!confirm('آیا از حذف کاربران انتخاب شده مطمئن هستید؟')){
+      if(!confirm('آیا از حذف کارکنان انتخاب شده مطمئن هستید؟')){
         e.preventDefault();
       }
     }

--- a/templates/core/manual_leave_form.html
+++ b/templates/core/manual_leave_form.html
@@ -3,7 +3,7 @@
 {% block management_content %}
 <h2 class="page-title">
   <i class="fas fa-calendar-plus"></i>
-  ثبت مرخصی برای کاربر
+  ثبت مرخصی برای کارمند
 </h2>
 <a class="btn" href="{% url 'leave_requests' %}" style="margin-bottom:1rem;">
   <i class="fas fa-chevron-right" style="margin-left:0.4rem;"></i> بازگشت

--- a/templates/core/register_face.html
+++ b/templates/core/register_face.html
@@ -6,6 +6,7 @@
 document.addEventListener('DOMContentLoaded', () => {
   const video = document.getElementById('video');
   const canvas = document.getElementById('canvas');
+  const ctx = canvas.getContext('2d');
   const btn = document.getElementById('captureBtn');
   const message = document.getElementById('captureResult');
 
@@ -29,7 +30,10 @@ document.addEventListener('DOMContentLoaded', () => {
     if (video.readyState !== video.HAVE_ENOUGH_DATA) return;
     canvas.width = video.videoWidth;
     canvas.height = video.videoHeight;
-    canvas.getContext('2d').drawImage(video, 0, 0, canvas.width, canvas.height);
+    ctx.save();
+    ctx.scale(-1, 1);
+    ctx.drawImage(video, -canvas.width, 0, canvas.width, canvas.height);
+    ctx.restore();
     captures.push(canvas.toDataURL('image/jpeg'));
     step++;
     if (step < steps.length) {

--- a/templates/core/register_face_for_user.html
+++ b/templates/core/register_face_for_user.html
@@ -1,6 +1,6 @@
 {% extends "core/base_device.html" %}
 {% load static %}
-{% block title %}ثبت چهره برای کاربر{% endblock %}
+{% block title %}ثبت چهره برای کارمند{% endblock %}
 {% block extra_css %}
 <style>
   .user-info-register {
@@ -26,6 +26,7 @@
 document.addEventListener('DOMContentLoaded', () => {
   const video = document.getElementById('video');
   const canvas = document.getElementById('canvas');
+  const ctx = canvas.getContext('2d');
   const btn = document.getElementById('captureBtn');
   const message = document.getElementById('captureResult');
 
@@ -49,7 +50,10 @@ document.addEventListener('DOMContentLoaded', () => {
     if (video.readyState !== video.HAVE_ENOUGH_DATA) return;
     canvas.width = video.videoWidth;
     canvas.height = video.videoHeight;
-    canvas.getContext('2d').drawImage(video, 0, 0, canvas.width, canvas.height);
+    ctx.save();
+    ctx.scale(-1, 1);
+    ctx.drawImage(video, -canvas.width, 0, canvas.width, canvas.height);
+    ctx.restore();
     captures.push(canvas.toDataURL('image/jpeg'));
     step++;
     if (step < steps.length) {
@@ -66,7 +70,7 @@ document.addEventListener('DOMContentLoaded', () => {
     .then(r => r.json())
     .then(data => {
       if (data.ok) {
-        message.textContent = "چهره کاربر با موفقیت ثبت شد.";
+        message.textContent = "چهره کارمند با موفقیت ثبت شد.";
         if (data.redirect) {
           setTimeout(() => { window.location.href = data.redirect; }, 1200);
         }

--- a/templates/core/shift_list.html
+++ b/templates/core/shift_list.html
@@ -8,7 +8,7 @@
 <div class="table-responsive">
 <table class="management-table">
   <thead>
-    <tr><th>نام</th><th>تعداد کاربران</th><th>شروع</th><th>پایان</th><th>عملیات</th></tr>
+    <tr><th>نام</th><th>تعداد کارکنان</th><th>شروع</th><th>پایان</th><th>عملیات</th></tr>
   </thead>
   <tbody>
   {% for s in shifts %}
@@ -56,7 +56,7 @@ document.querySelectorAll('.delete-item').forEach(btn => {
     const affected = this.dataset.affected;
     let msg = `آیا از حذف ${name} مطمئن هستید؟`;
     if(affected && parseInt(affected) > 0){
-      msg = `حذف ${name} بر روی ${affected} کاربر تأثیر خواهد گذاشت. آیا مطمئن هستید؟`;
+      msg = `حذف ${name} بر روی ${affected} کارمند تأثیر خواهد گذاشت. آیا مطمئن هستید؟`;
     }
     deleteMsg.textContent = msg;
     deleteForm.action = this.dataset.url;

--- a/templates/core/suspicious_logs.html
+++ b/templates/core/suspicious_logs.html
@@ -9,7 +9,7 @@
 <div class="request-cards">
   {% for log in logs %}
   <div class="request-card fade-in">
-    <div class="row"><span class="label">کاربر پیشنهادی:</span><span>{% if log.matched_user %}{{ log.matched_user.get_full_name }} - {{ log.matched_user.personnel_code }}{% else %}نامشخص{% endif %}</span></div>
+    <div class="row"><span class="label">کارمند پیشنهادی:</span><span>{% if log.matched_user %}{{ log.matched_user.get_full_name }} - {{ log.matched_user.personnel_code }}{% else %}نامشخص{% endif %}</span></div>
     <div class="row"><span class="label">فاصله:</span><span>{{ log.similarity|floatformat:3 }}</span></div>
     <div class="row"><span class="label">زمان:</span><span>{{ log.timestamp|jformat:"%Y/%m/%d %H:%M" }}</span></div>
     <div class="row"><span class="label">تصاویر:</span>
@@ -39,7 +39,7 @@
   <table class="management-table">
     <thead>
       <tr>
-        <th>کاربر پیشنهادی</th>
+        <th>کارمند پیشنهادی</th>
         <th>فاصله</th>
         <th>تصاویر</th>
         <th>زمان</th>

--- a/templates/core/user_form.html
+++ b/templates/core/user_form.html
@@ -1,11 +1,11 @@
 {% extends "core/base_management.html" %}
-{% block title %}{% if form.instance.pk %}ویرایش کاربر{% else %}افزودن کاربر{% endif %}{% endblock %}
+{% block title %}{% if form.instance.pk %}ویرایش کارمند{% else %}افزودن کارمند{% endif %}{% endblock %}
 {% block management_content %}
 <h2 style="text-align:right;">
   {% if form.instance.pk %}
-    <i class="fas fa-user-edit" style="margin-left:0.5rem;"></i> ویرایش کاربر
+    <i class="fas fa-user-edit" style="margin-left:0.5rem;"></i> ویرایش کارمند
   {% else %}
-    <i class="fas fa-user-plus" style="margin-left:0.5rem;"></i> افزودن کاربر جدید
+    <i class="fas fa-user-plus" style="margin-left:0.5rem;"></i> افزودن کارمند جدید
   {% endif %}
 </h2>
 <a class="btn" href="{% url 'management_users' %}" style="margin-bottom:1.1rem;">

--- a/templates/core/user_list.html
+++ b/templates/core/user_list.html
@@ -1,11 +1,11 @@
 {% extends "core/base_management.html" %}
-{% block title %}لیست کاربران{% endblock %}
+{% block title %}لیست کارکنان{% endblock %}
 {% block management_content %}
 <h2 style="text-align:right;">
-  <i class="fas fa-list" style="margin-left:0.5rem;"></i> لیست کاربران
+  <i class="fas fa-list" style="margin-left:0.5rem;"></i> لیست کارکنان
 </h2>
 <a class="btn" href="{% url 'user_add' %}" style="margin-bottom:1.2rem;">
-  <i class="fas fa-user-plus" style="margin-left:0.5rem;"></i> افزودن کاربر جدید
+  <i class="fas fa-user-plus" style="margin-left:0.5rem;"></i> افزودن کارمند جدید
 </a>
 <div class="request-cards">
   {% for u in users %}

--- a/templates/core/user_profile.html
+++ b/templates/core/user_profile.html
@@ -1,6 +1,6 @@
 {% extends "core/base.html" %}
 {% load static jformat %}
-{% block title %}پروفایل کاربر{% endblock %}
+{% block title %}پروفایل کارمند{% endblock %}
 {% block content %}
 <div class="card page page-md profile-card fade-in">
   <div class="profile-banner">

--- a/templates/core/user_reports.html
+++ b/templates/core/user_reports.html
@@ -1,20 +1,20 @@
 {% extends "core/base_management.html" %}
 {% load jformat %}
-{% block title %}گزارش کاربران{% endblock %}
+{% block title %}گزارش کارکنان{% endblock %}
 {% block management_content %}
 <h2 style="text-align:right;">
-  <i class="fas fa-file-alt" style="margin-left:0.5rem;"></i> گزارش کاربران
+  <i class="fas fa-file-alt" style="margin-left:0.5rem;"></i> گزارش کارکنان
  </h2>
 <div class="dashboard-stats">
   <div class="dashboard-card">
     <i class="fas fa-user-check"></i>
     <div class="value">{{ active_users }}</div>
-    <div class="label">کاربر فعال</div>
+    <div class="label">کارمند فعال</div>
   </div>
   <div class="dashboard-card">
     <i class="fas fa-user-times"></i>
     <div class="value">{{ inactive_users }}</div>
-    <div class="label">کاربر غیرفعال</div>
+    <div class="label">کارمند غیرفعال</div>
   </div>
   <div class="dashboard-card">
     <i class="fas fa-user-slash"></i>
@@ -63,7 +63,7 @@
     <table class="management-table">
       <thead>
         <tr>
-          <th>کاربر</th>
+          <th>کارمند</th>
           <th>تاریخ</th>
           <th>ساعت</th>
           <th>نوع</th>
@@ -77,7 +77,7 @@
           <td>{{ log.timestamp|jformat:"%Y/%m/%d" }}</td>
           <td>{{ log.timestamp|time:"H:i" }}</td>
           <td>{% if log.log_type == 'in' %}ورود{% else %}خروج{% endif %}</td>
-          <td>{% if log.source == 'self' %}کاربر{% elif log.source == 'auto' %}سیستم{% else %}مدیر{% endif %}</td>
+          <td>{% if log.source == 'self' %}کارمند{% elif log.source == 'auto' %}سیستم{% else %}مدیر{% endif %}</td>
         </tr>
         {% empty %}
         <tr><td colspan="5">ترددی ثبت نشده است.</td></tr>

--- a/templates/core/verify_face.html
+++ b/templates/core/verify_face.html
@@ -6,6 +6,7 @@
 document.addEventListener('DOMContentLoaded', () => {
   const video = document.getElementById('video');
   const canvas = document.getElementById('canvas');
+  const ctx = canvas.getContext('2d');
   const resultDiv = document.getElementById('verifyResult');
 
   if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
@@ -20,7 +21,10 @@ document.addEventListener('DOMContentLoaded', () => {
     if (video.readyState === video.HAVE_ENOUGH_DATA) {
       canvas.width = video.videoWidth;
       canvas.height = video.videoHeight;
-      canvas.getContext('2d').drawImage(video, 0, 0, canvas.width, canvas.height);
+      ctx.save();
+      ctx.scale(-1, 1);
+      ctx.drawImage(video, -canvas.width, 0, canvas.width, canvas.height);
+      ctx.restore();
       const dataUrl = canvas.toDataURL('image/jpeg');
       fetch("{% url 'api_verify_face' %}", {
         method: "POST",

--- a/users/admin.py
+++ b/users/admin.py
@@ -23,7 +23,7 @@ class CustomUserAdmin(UserAdmin):
         }),
     )
 
-    # ستون‌های لیست کاربران در صفحه ادمین
+    # ستون‌های لیست کارکنان در صفحه ادمین
     list_display = (
         "personnel_code",
         "first_name",


### PR DESCRIPTION
## Summary
- Mirror camera preview and captures so right-side gestures display correctly
- Rename "user" wording to "employee" across the interface
- Preserve leave request data during confirmation so submissions succeed

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689b6b4b0cc48333ad7fe6f84ba02525