### PR TITLE
Center home buttons and refine login forms

### DIFF
--- a/static/core/global.css
+++ b/static/core/global.css
@@ -173,6 +173,18 @@ button:hover, .btn:hover, input[type="submit"]:hover {
     text-decoration: none;
 }
 
+/* Home page buttons */
+.home-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+  align-items: center;
+}
+
+.home-buttons .btn {
+  width: 85%;
+}
+
 input, select, textarea {
   font-family: inherit;
   padding: 0.4rem 0.6rem;

--- a/static/core/login.css
+++ b/static/core/login.css
@@ -32,8 +32,10 @@
 }
 .login-container input[type="text"],
 .login-container input[type="password"] {
-  width: 100%;
+  width: 85%;
   text-align: right;
+  margin: 0 auto;
+  display: block;
 }
 .login-container .btn {
   width: 100%;

--- a/templates/core/home.html
+++ b/templates/core/home.html
@@ -5,7 +5,7 @@
   <h2 class="page-title">
     <i class="fas fa-id-card"></i> سامانه تردد
   </h2>
-  <div style="display:flex;flex-direction:column;gap:1.1rem;">
+  <div class="home-buttons">
     <a class="btn" href="{% url 'management_login' %}">
       <i class="fa fa-user-shield" style="margin-left:0.5rem;"></i> پنل مدیریت
     </a>

--- a/templates/core/management_login.html
+++ b/templates/core/management_login.html
@@ -26,6 +26,11 @@
     <button type="submit" class="btn" style="width:100%;">
       <i class="fa fa-arrow-right" style="margin-left:0.3rem;"></i> ورود
     </button>
+    <div class="login-links" style="margin-top:1.2rem;">
+      <a href="{% url 'home' %}" style="color:var(--color-muted);">
+        <i class="fa fa-arrow-left" style="margin-left:0.3rem;"></i> بازگشت به صفحه اصلی
+      </a>
+    </div>
   </form>
 </div>
 {% endblock %}

--- a/templates/core/user_inquiry.html
+++ b/templates/core/user_inquiry.html
@@ -1,9 +1,14 @@
 {% extends "core/base.html" %}
+{% load static %}
 {% block title %}مشاهده تردد من{% endblock %}
+{% block extra_css %}
+<link rel="stylesheet" href="{% static 'core/login.css' %}">
+{% endblock %}
 {% block content %}
-<div class="card page page-sm" style="margin-top:2.5rem;">
-  <h2 class="page-title">
-    <i class="fas fa-search"></i> مشاهده تردد من
+<div class="login-container card" style="margin-top:4rem;">
+  <h2 style="text-align:right;">
+    <i class="fas fa-search" style="margin-left:0.4rem;"></i>
+    مشاهده تردد من
   </h2>
   <form method="post" autocomplete="off">
     {% csrf_token %}
@@ -18,7 +23,12 @@
       {{ form.national_id.label_tag }}
       {{ form.national_id }}
     </div>
-    <button type="submit" class="btn"><i class="fas fa-search" style="margin-left:0.4rem;"></i> نمایش ترددها</button>
+    <button type="submit" class="btn" style="width:100%;"><i class="fas fa-search" style="margin-left:0.4rem;"></i> نمایش ترددها</button>
+    <div class="login-links" style="margin-top:1.2rem;">
+      <a href="{% url 'home' %}" style="color:var(--color-muted);">
+        <i class="fa fa-arrow-left" style="margin-left:0.3rem;"></i> بازگشت به صفحه اصلی
+      </a>
+    </div>
   </form>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Center home page buttons and reduce their width
- Resize login inputs and add back link for management login
- Style employee login page to match kiosk login design

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689b7a31307883338b16e1ea2921a16a