### PR TITLE
Use client-side today for Jalali date picker

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -138,6 +138,7 @@ class LeaveRequestForm(forms.ModelForm):
     def __init__(self, *args, user=None, **kwargs):
         self.user = user
         super().__init__(*args, **kwargs)
+        self.fields["start_date"].widget.attrs["data-jdp-min-date"] = "today"
 
     def clean(self):
         cleaned_data = super().clean()

--- a/static/core/global.js
+++ b/static/core/global.js
@@ -53,7 +53,9 @@ document.addEventListener("DOMContentLoaded", () => {
     jalaliDatepicker.startWatch({
       time: true,
       hasSecond: false,
-      separatorChars: { date: "-" }
+      separatorChars: { date: "-" },
+      minDate: "attr",
+      autoReadOnlyInput: true
     });
   }
 


### PR DESCRIPTION
## Summary
- Let Jalali date picker detect today's date in leave request forms
- Configure global date picker to read minDate from field attribute and disable manual typing

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689bc308dbac8333a6d7a3ef2742983e