### PR TITLE
Redesign attendance status sections

### DIFF
--- a/static/core/management.css
+++ b/static/core/management.css
@@ -271,24 +271,76 @@
   gap: 1rem;
   margin-top: 1rem;
 }
-.status-card {
-  background: var(--color-bg);
+
+.attendance-box {
+  background: var(--color-surface);
   border-radius: var(--radius);
-  box-shadow: var(--shadow);
   border: 1px solid var(--color-border);
-  padding: 0.8rem;
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  max-height: 280px;
 }
-.status-card h4 {
-  margin-bottom: 0.5rem;
+
+.box-header {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem;
   color: var(--color-primary-dark);
   font-size: 1.05rem;
+  font-weight: 600;
+  border-bottom: 1px solid var(--color-border);
+  position: sticky;
+  top: 0;
+  background: var(--color-surface);
+  z-index: 1;
+  direction: rtl;
 }
-.status-card ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  max-height: 220px;
+
+.box-header .badge {
+  background: var(--color-primary);
+  color: #fff;
+  border-radius: 9999px;
+  padding: 0 0.4rem;
+  font-size: 0.8rem;
+  line-height: 1.2;
+}
+
+.box-list {
+  padding: 0.5rem;
   overflow-y: auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 0.5rem;
+  direction: rtl;
+}
+
+.person-card {
+  background: #f8fafc;
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  padding: 0.4rem 0.6rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.95rem;
+  direction: rtl;
+}
+
+.person-name {
+  font-weight: 600;
+}
+
+.person-code {
+  color: var(--color-muted);
+  font-size: 0.9rem;
+}
+
+.empty {
+  text-align: center;
+  color: var(--color-muted);
 }
 
 .status-lists {

--- a/templates/core/attendance_status.html
+++ b/templates/core/attendance_status.html
@@ -15,55 +15,92 @@
   تاریخ: {{ jdate }}
 </div>
 <div class="status-grid">
-  <div class="status-card">
-    <h4>حاضرین</h4>
-    <ul id="present-list">
+  <div class="attendance-box">
+    <div class="box-header">
+      <span class="box-title">حاضرین</span>
+      <span class="badge" id="present-count">{{ present_users|length }}</span>
+    </div>
+    <div class="box-list" id="present-list">
       {% for u in present_users %}
-        <li>{{ u.get_full_name }} - {{ u.personnel_code }}</li>
+        <div class="person-card">
+          <span class="person-name">{{ u.get_full_name }}</span>
+          <span class="person-code">{{ u.personnel_code }}</span>
+        </div>
       {% empty %}
-        <li>موردی نیست</li>
+        <div class="empty">موردی نیست</div>
       {% endfor %}
-    </ul>
+    </div>
   </div>
-  <div class="status-card">
-    <h4>غایبین</h4>
-    <ul id="absent-list">
+  <div class="attendance-box">
+    <div class="box-header">
+      <span class="box-title">غایبین</span>
+      <span class="badge" id="absent-count">{{ absent_users|length }}</span>
+    </div>
+    <div class="box-list" id="absent-list">
       {% for u in absent_users %}
-        <li>{{ u.get_full_name }} - {{ u.personnel_code }}</li>
+        <div class="person-card">
+          <span class="person-name">{{ u.get_full_name }}</span>
+          <span class="person-code">{{ u.personnel_code }}</span>
+        </div>
       {% empty %}
-        <li>موردی نیست</li>
+        <div class="empty">موردی نیست</div>
       {% endfor %}
-    </ul>
+    </div>
   </div>
-  <div class="status-card">
-    <h4>مرخصی</h4>
-    <ul id="leave-list">
+  <div class="attendance-box">
+    <div class="box-header">
+      <span class="box-title">مرخصی</span>
+      <span class="badge" id="leave-count">{{ leave_users|length }}</span>
+    </div>
+    <div class="box-list" id="leave-list">
       {% for u in leave_users %}
-        <li>{{ u.get_full_name }} - {{ u.personnel_code }}</li>
+        <div class="person-card">
+          <span class="person-name">{{ u.get_full_name }}</span>
+          <span class="person-code">{{ u.personnel_code }}</span>
+        </div>
       {% empty %}
-        <li>موردی نیست</li>
+        <div class="empty">موردی نیست</div>
       {% endfor %}
-    </ul>
-</div>
+    </div>
+  </div>
 </div>
 {% endblock %}
 {% block extra_js %}
-{% if realtime %}
 <script>
+function updateInitialCounts(){
+  ['present','absent','leave'].forEach(type => {
+    const list = document.getElementById(type+'-list');
+    const badge = document.getElementById(type+'-count');
+    badge.textContent = list.querySelectorAll('.person-card').length;
+  });
+}
+updateInitialCounts();
+{% if realtime %}
 function refreshStatus(){
   const dateVal = document.getElementById('id_date').value;
   fetch("{% url 'api_attendance_status' %}?date=" + encodeURIComponent(dateVal))
     .then(r => r.json())
     .then(data => {
-      const present = document.getElementById('present-list');
-      present.innerHTML = data.present.map(u => `<li>${u.name} - ${u.code}</li>`).join('') || '<li>موردی نیست</li>';
-      const absent = document.getElementById('absent-list');
-      absent.innerHTML = data.absent.map(u => `<li>${u.name} - ${u.code}</li>`).join('') || '<li>موردی نیست</li>';
-      const leave = document.getElementById('leave-list');
-      leave.innerHTML = data.leave.map(u => `<li>${u.name} - ${u.code}</li>`).join('') || '<li>موردی نیست</li>';
+      const render = (items, listId, countId) => {
+        const list = document.getElementById(listId);
+        const count = document.getElementById(countId);
+        if(items.length){
+          list.innerHTML = items.map(u => `\
+            <div class="person-card">\
+              <span class="person-name">${u.name}</span>\
+              <span class="person-code">${u.code}</span>\
+            </div>`).join('');
+        }else{
+          list.innerHTML = '<div class="empty">موردی نیست</div>';
+        }
+        count.textContent = items.length;
+      };
+      render(data.present, 'present-list', 'present-count');
+      render(data.absent, 'absent-list', 'absent-count');
+      render(data.leave, 'leave-list', 'leave-count');
     });
 }
 setInterval(refreshStatus, 30000);
-</script>
 {% endif %}
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Style attendance status sections as boxed grids with scrollable card lists
- Add dynamic badges that count users automatically and refresh in real time

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689bda48cc9083338d953e4206b2b046