### PR TITLE
Redesign attendance status sections with card layout and live counts

### DIFF
--- a/static/core/management.css
+++ b/static/core/management.css
@@ -312,6 +312,13 @@
   gap: 0.6rem;
   overflow-y: auto;
   flex: 1;
+  max-height: 280px;
+}
+
+@media (min-width: 900px) {
+  .user-grid {
+    max-height: 360px;
+  }
 }
 .user-card {
   background: var(--color-bg);

--- a/static/core/management.css
+++ b/static/core/management.css
@@ -272,23 +272,62 @@
   margin-top: 1rem;
 }
 .status-card {
-  background: var(--color-bg);
+  background: var(--color-surface);
   border-radius: var(--radius);
   box-shadow: var(--shadow);
   border: 1px solid var(--color-border);
-  padding: 0.8rem;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
 }
-.status-card h4 {
-  margin-bottom: 0.5rem;
+.status-card-header {
+  position: sticky;
+  top: 0;
+  background: var(--color-surface);
+  text-align: center;
+  padding: 0.6rem;
+  border-bottom: 1px solid var(--color-border);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.4rem;
+}
+.status-card-header h4 {
+  margin: 0;
   color: var(--color-primary-dark);
   font-size: 1.05rem;
 }
-.status-card ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  max-height: 220px;
+.status-badge {
+  background: var(--color-primary);
+  color: #fff;
+  border-radius: 999px;
+  padding: 0 0.5rem;
+  font-size: 0.8rem;
+  line-height: 1.2;
+}
+.user-grid {
+  padding: 0.6rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 0.6rem;
   overflow-y: auto;
+  flex: 1;
+}
+.user-card {
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 0.6rem;
+  padding: 0.4rem 0.6rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.user-name {
+  font-weight: 700;
+}
+.user-code {
+  color: var(--color-muted);
+  font-size: 0.9rem;
 }
 
 .status-lists {

--- a/templates/core/attendance_status.html
+++ b/templates/core/attendance_status.html
@@ -16,35 +16,44 @@
 </div>
 <div class="status-grid">
   <div class="status-card">
-    <h4>حاضرین</h4>
-    <ul id="present-list">
+    <div class="status-card-header">
+      <h4>حاضرین</h4>
+      <span class="status-badge" id="present-count">{{ present_users|length }}</span>
+    </div>
+    <div class="user-grid" id="present-list">
       {% for u in present_users %}
-        <li>{{ u.get_full_name }} - {{ u.personnel_code }}</li>
+        <div class="user-card"><span class="user-name">{{ u.get_full_name }}</span><span class="user-code">{{ u.personnel_code }}</span></div>
       {% empty %}
-        <li>موردی نیست</li>
+        <div class="empty">موردی نیست</div>
       {% endfor %}
-    </ul>
+    </div>
   </div>
   <div class="status-card">
-    <h4>غایبین</h4>
-    <ul id="absent-list">
+    <div class="status-card-header">
+      <h4>غایبین</h4>
+      <span class="status-badge" id="absent-count">{{ absent_users|length }}</span>
+    </div>
+    <div class="user-grid" id="absent-list">
       {% for u in absent_users %}
-        <li>{{ u.get_full_name }} - {{ u.personnel_code }}</li>
+        <div class="user-card"><span class="user-name">{{ u.get_full_name }}</span><span class="user-code">{{ u.personnel_code }}</span></div>
       {% empty %}
-        <li>موردی نیست</li>
+        <div class="empty">موردی نیست</div>
       {% endfor %}
-    </ul>
+    </div>
   </div>
   <div class="status-card">
-    <h4>مرخصی</h4>
-    <ul id="leave-list">
+    <div class="status-card-header">
+      <h4>مرخصی</h4>
+      <span class="status-badge" id="leave-count">{{ leave_users|length }}</span>
+    </div>
+    <div class="user-grid" id="leave-list">
       {% for u in leave_users %}
-        <li>{{ u.get_full_name }} - {{ u.personnel_code }}</li>
+        <div class="user-card"><span class="user-name">{{ u.get_full_name }}</span><span class="user-code">{{ u.personnel_code }}</span></div>
       {% empty %}
-        <li>موردی نیست</li>
+        <div class="empty">موردی نیست</div>
       {% endfor %}
-    </ul>
-</div>
+    </div>
+  </div>
 </div>
 {% endblock %}
 {% block extra_js %}
@@ -56,11 +65,14 @@ function refreshStatus(){
     .then(r => r.json())
     .then(data => {
       const present = document.getElementById('present-list');
-      present.innerHTML = data.present.map(u => `<li>${u.name} - ${u.code}</li>`).join('') || '<li>موردی نیست</li>';
+      present.innerHTML = data.present.map(u => `<div class=\"user-card\"><span class=\"user-name\">${u.name}</span><span class=\"user-code\">${u.code}</span></div>`).join('') || '<div class="empty">موردی نیست</div>';
+      document.getElementById('present-count').textContent = data.present.length;
       const absent = document.getElementById('absent-list');
-      absent.innerHTML = data.absent.map(u => `<li>${u.name} - ${u.code}</li>`).join('') || '<li>موردی نیست</li>';
+      absent.innerHTML = data.absent.map(u => `<div class=\"user-card\"><span class=\"user-name\">${u.name}</span><span class=\"user-code\">${u.code}</span></div>`).join('') || '<div class="empty">موردی نیست</div>';
+      document.getElementById('absent-count').textContent = data.absent.length;
       const leave = document.getElementById('leave-list');
-      leave.innerHTML = data.leave.map(u => `<li>${u.name} - ${u.code}</li>`).join('') || '<li>موردی نیست</li>';
+      leave.innerHTML = data.leave.map(u => `<div class=\"user-card\"><span class=\"user-name\">${u.name}</span><span class=\"user-code\">${u.code}</span></div>`).join('') || '<div class="empty">موردی نیست</div>';
+      document.getElementById('leave-count').textContent = data.leave.length;
     });
 }
 setInterval(refreshStatus, 30000);


### PR DESCRIPTION
## Summary
- restyle attendance status sections with sticky header, badge counts, and grid-based user cards
- add responsive card styling in management.css for clear RTL presentation
- update realtime script to rebuild card lists and refresh counts

## Testing
- ✅ `python manage.py check`
- ✅ `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689bda48cc9083338d953e4206b2b046