### PR TITLE
Refine leave request date display and mobile actions

### DIFF
--- a/static/core/management.css
+++ b/static/core/management.css
@@ -454,6 +454,15 @@
   gap: 0.4rem;
   margin-top: 0.6rem;
 }
+.request-card .action-buttons {
+  display: flex;
+  width: 100%;
+  gap: 0.4rem;
+}
+.request-card .action-buttons button {
+  flex: 1;
+  margin: 0;
+}
 
 /* small-screen adjustments */
 @media (max-width: 900px) {

--- a/templates/core/leave_requests.html
+++ b/templates/core/leave_requests.html
@@ -28,8 +28,9 @@
   {% for r in requests %}
   <div class="request-card fade-in">
     <div class="row"><span class="label">کارمند:</span><span>{{ r.user.get_full_name }} - {{ r.user.personnel_code }}</span></div>
-    <div class="row"><span class="label">از:</span><span>{{ r.start_date|jformat:"%Y/%m/%d" }}</span></div>
-    <div class="row"><span class="label">تا:</span><span>{{ r.end_date|jformat:"%Y/%m/%d" }}</span></div>
+    <div class="row"><span class="label">از تا:</span>
+      <span class="date-range">{{ r.start_date|jformat:"%Y/%m/%d" }}<br>تا<br>{{ r.end_date|jformat:"%Y/%m/%d" }}</span>
+    </div>
     {% if r.leave_type %}<div class="row"><span class="label">نوع:</span><span>{{ r.leave_type }}</span></div>{% endif %}
     <div class="row"><span class="label">توضیح:</span><span>{{ r.reason|default:"-" }}</span></div>
     <div class="row"><span class="label">وضعیت:</span>
@@ -43,9 +44,11 @@
         {% csrf_token %}
         <input type="hidden" name="req_id" value="{{ r.id }}">
         <input type="text" name="manager_note" placeholder="توضیح" style="flex:1;min-width:80px;">
-        <button name="action" value="approve" class="btn" style="font-size:0.9rem;">تأیید</button>
-        <button name="action" value="reject" class="btn btn-danger" style="font-size:0.9rem;">رد</button>
-        <button name="action" value="cancel" class="btn" style="background:var(--color-muted);font-size:0.9rem;">لغو</button>
+        <div class="action-buttons" style="width:100%;">
+          <button name="action" value="approve" class="btn" style="font-size:0.9rem;">تأیید</button>
+          <button name="action" value="reject" class="btn btn-danger" style="font-size:0.9rem;">رد</button>
+          <button name="action" value="cancel" class="btn" style="background:var(--color-muted);font-size:0.9rem;">لغو</button>
+        </div>
       </form>
       {% elif r.start_date > today %}
       <form method="post" class="actions" style="flex:1;">
@@ -75,8 +78,7 @@
   <thead>
     <tr>
       <th>کارمند</th>
-      <th>از</th>
-      <th>تا</th>
+      <th>از تا</th>
       <th>نوع</th>
       <th>توضیح</th>
       <th>وضعیت</th>
@@ -87,8 +89,7 @@
     {% for r in requests %}
     <tr>
       <td>{{ r.user.get_full_name }} - {{ r.user.personnel_code }}</td>
-      <td>{{ r.start_date|jformat:"%Y/%m/%d" }}</td>
-      <td>{{ r.end_date|jformat:"%Y/%m/%d" }}</td>
+      <td>{{ r.start_date|jformat:"%Y/%m/%d" }}<br>تا<br>{{ r.end_date|jformat:"%Y/%m/%d" }}</td>
       <td>{{ r.leave_type|default:"-" }}</td>
       <td>{{ r.reason|default:"-" }}</td>
       <td>
@@ -123,7 +124,7 @@
       </td>
     </tr>
     {% empty %}
-    <tr><td colspan="7">درخواستی وجود ندارد.</td></tr>
+    <tr><td colspan="6">درخواستی وجود ندارد.</td></tr>
     {% endfor %}
   </tbody>
 </table>


### PR DESCRIPTION
## Summary
- combine start and end dates into single stacked field on leave request pages
- show approve/reject/cancel buttons in one row on mobile

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689be71134448333a97f39ddb5effb74