### PR TITLE
Standardize quick action buttons styling

### DIFF
--- a/static/core/management.css
+++ b/static/core/management.css
@@ -471,11 +471,6 @@
   border-bottom: none;
 }
 
-.btn-small {
-  padding: 0.2rem 0.6rem;
-  font-size: 0.85rem;
-}
-
 
 /* responsive cards used for leave/edit requests */
 .request-cards { display: none; }

--- a/templates/core/management_dashboard.html
+++ b/templates/core/management_dashboard.html
@@ -100,14 +100,14 @@
           <input type="hidden" name="req_id" value="{{ r.id }}">
           <input type="hidden" name="action" value="approve">
           <input type="hidden" name="next" value="management_dashboard">
-          <button class="btn btn-small" type="submit">تأیید</button>
+          <button class="btn" type="submit">تأیید</button>
         </form>
         <form method="post" action="{{ r.action_url }}" style="display:inline-block;">
           {% csrf_token %}
           <input type="hidden" name="req_id" value="{{ r.id }}">
           <input type="hidden" name="action" value="reject">
           <input type="hidden" name="next" value="management_dashboard">
-          <button class="btn btn-small" type="submit" style="background:var(--color-muted);color:#fff;">رد</button>
+          <button class="btn btn-danger" type="submit">رد</button>
         </form>
       </div>
     </div>
@@ -132,14 +132,14 @@
               <input type="hidden" name="req_id" value="{{ r.id }}">
               <input type="hidden" name="action" value="approve">
               <input type="hidden" name="next" value="management_dashboard">
-              <button class="btn btn-small" type="submit">تأیید</button>
+              <button class="btn" type="submit">تأیید</button>
             </form>
             <form method="post" action="{{ r.action_url }}" style="display:inline-block;">
               {% csrf_token %}
               <input type="hidden" name="req_id" value="{{ r.id }}">
               <input type="hidden" name="action" value="reject">
               <input type="hidden" name="next" value="management_dashboard">
-              <button class="btn btn-small" type="submit" style="background:var(--color-muted);color:#fff;">رد</button>
+              <button class="btn btn-danger" type="submit">رد</button>
             </form>
           </td>
         </tr>


### PR DESCRIPTION
## Summary
- use site-standard `btn` and `btn-danger` styles for immediate action buttons
- drop custom `.btn-small` rule from management CSS

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689c4be206388333a4649764bd69cb3c