### PR TITLE
Refactor monthly performance calculation

### DIFF
--- a/templates/core/user_profile.html
+++ b/templates/core/user_profile.html
@@ -44,13 +44,14 @@
         <span>{{ log_jyear }}/{{ log_jmonth|stringformat:"02d" }}/{{ day|stringformat:"02d" }}</span>
         <span>{% if info.in %}{{ info.in|time:"H:i" }}{% else %}-{% endif %}</span>
         <span>{% if info.out %}{{ info.out|time:"H:i" }}{% else %}-{% endif %}</span>
+        <span>{% if info.status == 'incomplete' %}ناقص{% elif info.status == 'absent' %}غیبت{% else %}-{% endif %}</span>
       </div>
       {% endfor %}
     </div>
     <div class="table-responsive desktop-only">
       <table class="management-table">
         <thead>
-          <tr><th>تاریخ</th><th>ورود</th><th>خروج</th></tr>
+          <tr><th>تاریخ</th><th>ورود</th><th>خروج</th><th>وضعیت</th></tr>
         </thead>
         <tbody>
           {% for day, info in daily_logs.items %}
@@ -58,6 +59,7 @@
             <td>{{ log_jyear }}/{{ log_jmonth|stringformat:"02d" }}/{{ day|stringformat:"02d" }}</td>
             <td>{% if info.in %}{{ info.in|time:"H:i" }}{% else %}-{% endif %}</td>
             <td>{% if info.out %}{{ info.out|time:"H:i" }}{% else %}-{% endif %}</td>
+            <td>{% if info.status == 'incomplete' %}ناقص{% elif info.status == 'absent' %}غیبت{% else %}-{% endif %}</td>
           </tr>
           {% endfor %}
         </tbody>


### PR DESCRIPTION
## Summary
- Deduplicate monthly performance logic into `_calculate_monthly_performance`
- Use shared monthly performance calculation in user and management views

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689ca222af08833398b7663fc50086f4