### PR TITLE
Refactor monthly performance calculation

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -3,6 +3,7 @@ import io
 import json
 import secrets
 import os
+import math
 from datetime import timedelta, datetime, time
 
 import face_recognition
@@ -80,6 +81,170 @@ def _shift_bounds(date, shift):
 def _weekday_index(date):
     """Convert Python weekday (Mon=0) to app convention (Sat=0)."""
     return (date.weekday() + 2) % 7
+
+
+def _calculate_monthly_performance(user, year, month):
+    """Return standard monthly performance report and related leaves."""
+    start_j = jdatetime.date(year, month, 1)
+    days_in_month = jdatetime.j_days_in_month[month - 1]
+    today_j = jdatetime.date.today()
+    if year == today_j.year and month == today_j.month:
+        days_in_month = today_j.day
+        end_j = today_j
+    else:
+        end_j = jdatetime.date(year, month, days_in_month)
+    start_g = start_j.togregorian()
+    end_g = end_j.togregorian()
+
+    shift = _get_user_shift(user)
+    shift_start = shift.start_time if shift else time(9, 0)
+    shift_end = shift.end_time if shift else time(17, 0)
+
+    EARLY_TOL = timedelta(minutes=30)
+    LATE_TOL = timedelta(minutes=30)
+
+    global_start = datetime.combine(start_g, shift_start) - EARLY_TOL
+    global_end = datetime.combine(end_g, shift_end) + LATE_TOL
+    if shift_end <= shift_start:
+        global_end += timedelta(days=1)
+
+    logs = list(
+        AttendanceLog.objects.filter(
+            user=user, timestamp__gte=global_start, timestamp__lt=global_end
+        ).order_by("timestamp")
+    )
+
+    weekly_holidays = set(WeeklyHoliday.objects.values_list("weekday", flat=True))
+
+    leaves_qs = LeaveRequest.objects.filter(
+        user=user,
+        status="approved",
+        start_date__lte=end_g,
+        end_date__gte=start_g,
+    )
+    leave_days = set()
+    for leave in leaves_qs:
+        cur = max(leave.start_date, start_g)
+        while cur <= min(leave.end_date, end_g):
+            leave_days.add(cur)
+            cur += timedelta(days=1)
+
+    if shift_end <= shift_start:
+        shift_minutes = (
+            datetime.combine(start_g, shift_end)
+            + timedelta(days=1)
+            - datetime.combine(start_g, shift_start)
+        ).seconds // 60
+    else:
+        shift_minutes = (
+            datetime.combine(start_g, shift_end)
+            - datetime.combine(start_g, shift_start)
+        ).seconds // 60
+
+    present_minutes = 0
+    mandatory_minutes = 0
+    tardy_minutes = 0
+    overtime_minutes = 0
+    absence_days = 0
+    incomplete_days = []
+
+    i = 0
+    for d in range(days_in_month):
+        day = start_g + timedelta(days=d)
+        if _weekday_index(day) in weekly_holidays or day in leave_days:
+            continue
+        mandatory_minutes += shift_minutes
+
+        start_dt = datetime.combine(day, shift_start)
+        end_dt = datetime.combine(day, shift_end)
+        if shift_end <= shift_start:
+            end_dt += timedelta(days=1)
+
+        window_start = start_dt - EARLY_TOL
+        window_end = end_dt + LATE_TOL
+
+        day_logs = []
+        prev_log = logs[i - 1] if i > 0 else None
+        while i < len(logs) and logs[i].timestamp < window_start:
+            prev_log = logs[i]
+            i += 1
+        j = i
+        while j < len(logs) and logs[j].timestamp < window_end:
+            day_logs.append(logs[j])
+            j += 1
+        i = j
+
+        session_pairs = []
+        incomplete = False
+        current_in = None
+        if prev_log and prev_log.log_type == "in":
+            current_in = prev_log.timestamp
+        for log in day_logs:
+            if log.log_type == "in":
+                if current_in is not None:
+                    session_pairs.append((current_in, log.timestamp))
+                    incomplete = True
+                current_in = log.timestamp
+            else:  # out
+                if current_in is not None:
+                    session_pairs.append((current_in, log.timestamp))
+                    current_in = None
+                else:
+                    incomplete = True
+        if current_in is not None:
+            session_pairs.append((current_in, window_end))
+            incomplete = True
+
+        if not session_pairs and not day_logs and not (
+            prev_log and prev_log.log_type == "in"
+        ):
+            absence_days += 1
+            continue
+
+        if incomplete:
+            incomplete_days.append(day)
+
+        if prev_log and prev_log.log_type == "in":
+            first_in_ts = start_dt
+        else:
+            first_in_ts = None
+            for l in day_logs:
+                if l.log_type == "in":
+                    first_in_ts = l.timestamp
+                    break
+
+        if first_in_ts and first_in_ts > start_dt:
+            tardy_minutes += int(
+                math.ceil((first_in_ts - start_dt).total_seconds() / 60)
+            )
+
+        for in_ts, out_ts in session_pairs:
+            overlap_start = max(in_ts, start_dt)
+            overlap_end = min(out_ts, end_dt)
+            if overlap_start < overlap_end:
+                present_minutes += int(
+                    (overlap_end - overlap_start).total_seconds() // 60
+                )
+            if in_ts < start_dt:
+                overtime_minutes += int(
+                    (min(out_ts, start_dt) - in_ts).total_seconds() // 60
+                )
+            if out_ts > end_dt:
+                overtime_minutes += int(
+                    (out_ts - max(in_ts, end_dt)).total_seconds() // 60
+                )
+
+    report = {
+        "present_minutes": present_minutes,
+        "mandatory_minutes": mandatory_minutes,
+        "tardy_minutes": tardy_minutes,
+        "absence_days": absence_days,
+        "present_hours": round(present_minutes / 60, 2),
+        "required_hours": round(mandatory_minutes / 60, 2),
+        "overtime_minutes": overtime_minutes,
+        "incomplete_days": [d for d in incomplete_days],
+    }
+    return report, list(leaves_qs)
 
 
 def _get_face_encoding_from_base64(data_url: str):
@@ -360,54 +525,11 @@ def user_profile(request):
 
     # Monthly performance statistics
     today_j = jdatetime.date.today()
-    jy, jm = today_j.year, today_j.month
-    days_in_month = jdatetime.j_days_in_month[jm - 1]
-    total_work_seconds = 0
-    total_delay_seconds = 0
-    absent_days = 0
-    shift = _get_user_shift(u)
-    default_start = time(9, 0)
-    default_end = time(17, 0)
-    for d in range(1, days_in_month + 1):
-        date_j = jdatetime.date(jy, jm, d)
-        date_g = date_j.togregorian()
-        if date_g > today:
-            break
-        if WeeklyHoliday.objects.filter(weekday=_weekday_index(date_g)).exists():
-            continue
-        if LeaveRequest.objects.filter(
-            user=u,
-            status="approved",
-            start_date__lte=date_g,
-            end_date__gte=date_g,
-        ).exists():
-            continue
-        logs = AttendanceLog.objects.filter(user=u, timestamp__date=date_g).order_by("timestamp")
-        if logs.exists():
-            first_log = logs.first().timestamp
-            last_log = logs.last().timestamp
-            shift_start = shift.start_time if shift else default_start
-            shift_end = shift.end_time if shift else default_end
-            start_dt = datetime.combine(date_g, shift_start)
-            end_dt = datetime.combine(date_g, shift_end)
-            if shift_end <= shift_start:
-                end_dt += timedelta(days=1)
-            if first_log.tzinfo is not None:
-                first_log = first_log.replace(tzinfo=None)
-            if last_log.tzinfo is not None:
-                last_log = last_log.replace(tzinfo=None)
-            work_start = max(first_log, start_dt)
-            work_end = min(last_log, end_dt)
-            if work_end > work_start:
-                total_work_seconds += (work_end - work_start).total_seconds()
-            if first_log > start_dt:
-                total_delay_seconds += (first_log - start_dt).total_seconds()
-        else:
-            absent_days += 1
+    report, _ = _calculate_monthly_performance(u, today_j.year, today_j.month)
     monthly_stats = {
-        "total_hours": round(total_work_seconds / 3600, 2),
-        "total_delay": int(total_delay_seconds / 60),
-        "absent_days": absent_days,
+        "total_hours": report["present_hours"],
+        "total_delay": report["tardy_minutes"],
+        "absent_days": report["absence_days"],
     }
 
     # Attendance logs for selected month
@@ -418,9 +540,19 @@ def user_profile(request):
         t = jdatetime.date.today()
         ly, lm = t.year, t.month
     days = jdatetime.j_days_in_month[lm - 1]
-    start_g = jdatetime.date(ly, lm, 1).togregorian()
-    end_g = jdatetime.date(ly, lm, days).togregorian()
-    qs = AttendanceLog.objects.filter(user=u, timestamp__date__range=(start_g, end_g)).order_by("timestamp")
+    start_j = jdatetime.date(ly, lm, 1)
+    end_j = jdatetime.date(ly, lm, days)
+    today_j = jdatetime.date.today()
+    if ly == today_j.year and lm == today_j.month:
+        days = today_j.day
+        end_j = today_j
+    start_g = start_j.togregorian()
+    end_g = end_j.togregorian()
+    start_dt = datetime.combine(start_g, time.min)
+    end_dt = datetime.combine(end_g + timedelta(days=1), time.min)
+    qs = AttendanceLog.objects.filter(
+        user=u, timestamp__gte=start_dt, timestamp__lt=end_dt
+    ).order_by("timestamp")
     daily_logs = {d: {"in": None, "out": None} for d in range(1, days + 1)}
     for log in qs:
         jd = jdatetime.date.fromgregorian(date=log.timestamp.date())
@@ -429,8 +561,8 @@ def user_profile(request):
             info["in"] = log.timestamp.time()
         if log.log_type == "out":
             info["out"] = log.timestamp.time()
-    prev_m = (jdatetime.date(ly, lm, 1) - jdatetime.timedelta(days=1))
-    next_m = (jdatetime.date(ly, lm, days) + jdatetime.timedelta(days=1))
+    prev_m = (start_j - jdatetime.timedelta(days=1))
+    next_m = (end_j + jdatetime.timedelta(days=1))
 
     edit_requests = EditRequest.objects.filter(user=u).order_by("-created_at")
     leave_requests = LeaveRequest.objects.select_related("leave_type").filter(user=u).order_by("-created_at")
@@ -1031,109 +1163,21 @@ def user_reports(request):
 def monthly_profile(request):
     form = MonthlyPerformanceForm(request.GET or None)
     report = None
-    logs = []
     leaves = []
     selected_user = None
     if form.is_valid():
-        selected_user = form.cleaned_data['user']
-        year = form.cleaned_data['year']
-        month = int(form.cleaned_data['month'])
-        start_j = jdatetime.date(year, month, 1)
-        if month == 12:
-            next_month = jdatetime.date(year + 1, 1, 1)
-        else:
-            next_month = jdatetime.date(year, month + 1, 1)
-        end_j = next_month - jdatetime.timedelta(days=1)
-        start_g = start_j.togregorian()
-        end_g = end_j.togregorian()
-        logs_qs = AttendanceLog.objects.filter(
-            user=selected_user,
-            timestamp__date__range=(start_g, end_g)
-        ).order_by('timestamp')
-        logs = list(logs_qs)
-        logs_by_day = {}
-        for log in logs:
-            logs_by_day.setdefault(log.timestamp.date(), []).append(log)
-
-        # prepare leave days
-        leaves = LeaveRequest.objects.filter(
-            user=selected_user,
-            start_date__lte=end_g,
-            end_date__gte=start_g,
-            status='approved'
-        )
-        leave_days = set()
-        for leave in leaves:
-            cur = max(leave.start_date, start_g)
-            while cur <= min(leave.end_date, end_g):
-                leave_days.add(cur)
-                cur += timedelta(days=1)
-
-        shift = _get_user_shift(selected_user)
-        shift_start = time(9, 0)
-        shift_end = time(17, 0)
-        if shift:
-            shift_start = shift.start_time
-            shift_end = shift.end_time
-        # shift duration
-        if shift_end <= shift_start:
-            shift_minutes = (
-                datetime.combine(start_g, shift_end) + timedelta(days=1) - datetime.combine(start_g, shift_start)
-            ).seconds // 60
-        else:
-            shift_minutes = (
-                datetime.combine(start_g, shift_end) - datetime.combine(start_g, shift_start)
-            ).seconds // 60
-
-        weekly_holidays = set(WeeklyHoliday.objects.values_list('weekday', flat=True))
-
-        day = start_g
-        total_minutes = 0
-        mandatory_minutes = 0
-        tardy_minutes = 0
-        absence_days = 0
-        while day <= end_g:
-            if _weekday_index(day) in weekly_holidays or day in leave_days:
-                day += timedelta(days=1)
-                continue
-            mandatory_minutes += shift_minutes
-            day_logs = logs_by_day.get(day, [])
-            if day_logs:
-                current_in = None
-                for log in day_logs:
-                    if log.log_type == 'in':
-                        current_in = log.timestamp
-                    elif log.log_type == 'out' and current_in:
-                        total_minutes += int((log.timestamp - current_in).total_seconds() // 60)
-                        current_in = None
-                first_log = day_logs[0]
-                shift_start_dt = datetime.combine(day, shift_start)
-                fl_ts = first_log.timestamp
-                if fl_ts.tzinfo is not None:
-                    fl_ts = fl_ts.replace(tzinfo=None)
-                if fl_ts > shift_start_dt:
-                    tardy_minutes += int((fl_ts - shift_start_dt).total_seconds() // 60)
-            else:
-                absence_days += 1
-            day += timedelta(days=1)
-
-        overtime_minutes = total_minutes - mandatory_minutes
-        report = {
-            'required_hours': round(mandatory_minutes / 60, 2),
-            'present_hours': round(total_minutes / 60, 2),
-            'overtime_minutes': overtime_minutes,
-            'absence_days': absence_days,
-            'tardy_minutes': tardy_minutes,
-        }
+        selected_user = form.cleaned_data["user"]
+        year = form.cleaned_data["year"]
+        month = int(form.cleaned_data["month"])
+        report, leaves = _calculate_monthly_performance(selected_user, year, month)
     context = {
-        'active_tab': 'reports',
-        'form': form,
-        'report': report,
-        'logs': logs,
-        'leaves': leaves,
-        'selected_user': selected_user,
+        "active_tab": "reports",
+        "form": form,
+        "report": report,
+        "leaves": leaves,
+        "selected_user": selected_user,
     }
-    return render(request, 'core/monthly_profile.html', context)
+    return render(request, "core/monthly_profile.html", context)
 
 
 @login_required

--- a/templates/core/monthly_profile.html
+++ b/templates/core/monthly_profile.html
@@ -32,5 +32,15 @@
   </ul>
 </div>
 {% endif %}
+{% if report.incomplete_days %}
+<div class="card" style="margin-top:1rem;">
+  <h4>تردد ناقص</h4>
+  <ul>
+    {% for d in report.incomplete_days %}
+      <li>{{ d|jformat:"%Y/%m/%d" }}</li>
+    {% endfor %}
+  </ul>
+</div>
+{% endif %}
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- Expand monthly log range with tolerance around shift start and end to preserve early/late events
- Pair logs without trimming to shift bounds, computing tardiness and overtime from resulting sessions
- Count absences only on workdays with no logs and flag true pairing issues as incomplete

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689ca222af08833398b7663fc50086f4