### PR TITLE
chore: remove unused helpers

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -8,7 +8,6 @@ from attendance.models import (
     EditRequest,
     LeaveRequest,
     LOG_TYPE_CHOICES,
-    WeeklyHoliday,
     Group,
     Shift,
 )
@@ -337,7 +336,6 @@ class ReportFilterForm(forms.Form):
             attrs={
                 "placeholder": "۱۴۰۳/۰۵/۱۰",
                 "class": "date-input vjDateField",
-                "readonly": "readonly",
             }
         ),
         required=False,
@@ -348,7 +346,6 @@ class ReportFilterForm(forms.Form):
             attrs={
                 "placeholder": "۱۴۰۳/۰۵/۱۰",
                 "class": "date-input vjDateField",
-                "readonly": "readonly",
             }
         ),
         required=False,


### PR DESCRIPTION
## Summary
- prune unused imports and helper functions in core views
- drop redundant readonly attributes from date fields

## Testing
- `ruff check core/views.py core/forms.py`
- `black --check core/views.py core/forms.py` *(fails: would reformat)*
- `isort --check core/views.py core/forms.py` *(fails: imports not sorted)*
- `python -m compileall core/forms.py core/views.py`
- `python manage.py check`
- `python manage.py check --deploy` *(warnings)*
- `python manage.py makemigrations --check` *(fails: migrations needed)*
- `pytest -q`
- `python manage.py shell -c 'from django.urls import reverse; print(reverse("home"), reverse("user_profile"), reverse("weekly_holidays"))'`
- `python manage.py shell -c 'from django.template.loader import render_to_string; print(render_to_string("core/weekly_holidays.html", {"existing": []})[:60])'`
- `python manage.py collectstatic --dry-run --noinput` *(fails: STATIC_ROOT not configured)*


------
https://chatgpt.com/codex/tasks/task_e_689efa3e0d90833387e4c36ed6b62cd3