### PR TITLE
Unify face verification and liveness logic

### DIFF
--- a/templates/core/device_face_check.html
+++ b/templates/core/device_face_check.html
@@ -9,12 +9,12 @@ document.addEventListener('DOMContentLoaded', () => {
   const ctx = canvas.getContext('2d');
   const btn = document.getElementById('verifyBtn');
   const message = document.getElementById('verifyResult');
-
-  message.textContent = 'صورت خود را در مرکز کادر قرار دهید و دکمه تأیید را بزنید';
+  message.textContent = 'برای شروع دکمه را بزنید و مستقیم نگاه کنید.';
+  let captures = [];
 
   if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
     navigator.mediaDevices.getUserMedia({ video: { facingMode: "user" } })
-      .then(stream => { video.srcObject = stream; message.textContent = ''; })
+      .then(stream => { video.srcObject = stream; })
       .catch(() => { message.textContent = 'دسترسی به دوربین ممکن نشد.'; btn.disabled = true; });
   } else {
     message.textContent = 'دوربین توسط مرورگر پشتیبانی نمی‌شود.';
@@ -22,38 +22,47 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   btn.onclick = () => {
-    if (video.readyState !== video.HAVE_ENOUGH_DATA) {
-      message.textContent = 'لطفاً صبر کنید تا تصویر دوربین آماده شود';
-      return;
-    }
+    if (video.readyState !== video.HAVE_ENOUGH_DATA) return;
     btn.disabled = true;
+    captures = [];
+    message.textContent = 'لطفاً مستقیم نگاه کنید...';
+    setTimeout(() => {
+      captures.push(capture());
+      message.textContent = 'حالا سرتان را کمی به چپ یا راست بچرخانید.';
+      setTimeout(() => {
+        captures.push(capture());
+        message.textContent = 'لطفاً صبر کنید...';
+        fetch("{% url 'api_device_verify_face' %}", {
+          method: 'POST',
+          headers: { "Content-Type": "application/json", "X-CSRFToken": getCsrfToken() },
+          body: JSON.stringify({ image1: captures[0], image2: captures[1] })
+        })
+          .then(r => r.json())
+          .then(data => {
+            if (data.success) {
+              message.textContent = "چهره تأیید شد. کیوسک فعال شد.";
+              setTimeout(() => { window.location.href = data.redirect; }, 1000);
+            } else {
+              message.textContent = data.error || "چهره مطابقت نداشت.";
+              btn.disabled = false;
+            }
+          }).catch(() => {
+            message.textContent = "ارتباط با سرور برقرار نشد.";
+            btn.disabled = false;
+          });
+      }, 3000);
+    }, 1000);
+  };
+
+  function capture() {
     canvas.width = video.videoWidth;
     canvas.height = video.videoHeight;
     ctx.save();
     ctx.scale(-1, 1);
     ctx.drawImage(video, -canvas.width, 0, canvas.width, canvas.height);
     ctx.restore();
-    const dataUrl = canvas.toDataURL('image/jpeg');
-    message.textContent = 'لطفاً صبر کنید...';
-    fetch("{% url 'api_device_verify_face' %}", {
-      method: 'POST',
-      headers: { "Content-Type": "application/json", "X-CSRFToken": getCsrfToken() },
-      body: JSON.stringify({ image: dataUrl })
-    })
-    .then(r => r.json())
-    .then(data => {
-      if (data.success) {
-        message.textContent = "چهره تأیید شد. کیوسک فعال شد.";
-        setTimeout(() => { window.location.href = data.redirect; }, 1000);
-      } else {
-        message.textContent = data.error || "چهره مطابقت نداشت.";
-        btn.disabled = false;
-      }
-    }).catch(() => {
-      message.textContent = "ارتباط با سرور برقرار نشد.";
-      btn.disabled = false;
-    });
-  };
+    return canvas.toDataURL('image/jpeg');
+  }
 
   function getCsrfToken() {
     let value = "; " + document.cookie;

--- a/templates/core/management_face_check.html
+++ b/templates/core/management_face_check.html
@@ -9,12 +9,12 @@ document.addEventListener('DOMContentLoaded', () => {
   const ctx = canvas.getContext('2d');
   const btn = document.getElementById('verifyBtn');
   const msgEl = document.getElementById('verifyResult');
-
-  msgEl.textContent = 'صورت خود را در مرکز کادر قرار دهید و دکمه تأیید را بزنید';
+  msgEl.textContent = 'برای شروع دکمه را بزنید و مستقیم نگاه کنید.';
+  let captures = [];
 
   if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
     navigator.mediaDevices.getUserMedia({ video: { facingMode: "user" } })
-      .then(stream => { video.srcObject = stream; msgEl.textContent = ''; })
+      .then(stream => { video.srcObject = stream; })
       .catch(() => { msgEl.textContent = 'اجازه دوربین رد شد'; btn.disabled = true; });
   } else {
     msgEl.textContent = 'دوربین توسط مرورگر پشتیبانی نمی‌شود.';
@@ -22,42 +22,50 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   btn.onclick = async () => {
-    if (video.readyState !== video.HAVE_ENOUGH_DATA) {
-      msgEl.textContent = 'لطفاً صبر کنید تا تصویر دوربین آماده شود';
-      return;
-    }
+    if (video.readyState !== video.HAVE_ENOUGH_DATA) return;
     btn.disabled = true;
+    captures = [];
+    msgEl.textContent = 'لطفاً مستقیم نگاه کنید...';
+    setTimeout(async () => {
+      captures.push(capture());
+      msgEl.textContent = 'حالا سرتان را کمی به چپ یا راست بچرخانید.';
+      setTimeout(async () => {
+        captures.push(capture());
+        msgEl.textContent = 'لطفاً صبر کنید...';
+        try {
+          const res = await fetch('{% url "api_management_verify_face" %}', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'X-CSRFToken': getCsrf()
+            },
+            body: JSON.stringify({ image1: captures[0], image2: captures[1] })
+          });
+          const j = await res.json();
+          if (j.success) {
+            msgEl.textContent = '✅ تأیید چهره موفق!';
+            setTimeout(() => { window.location.href = '{% url "management_dashboard" %}'; }, 1000);
+          } else {
+            msgEl.textContent = '❌ ' + (j.error || 'شناسایی ناموفق');
+            btn.disabled = false;
+          }
+        } catch (e) {
+          msgEl.textContent = '❌ خطا در ارتباط با سرور';
+          btn.disabled = false;
+        }
+      }, 3000);
+    }, 1000);
+  };
+
+  function capture() {
     canvas.width = video.videoWidth;
     canvas.height = video.videoHeight;
     ctx.save();
     ctx.scale(-1, 1);
     ctx.drawImage(video, -canvas.width, 0, canvas.width, canvas.height);
     ctx.restore();
-    const dataUrl = canvas.toDataURL('image/png');
-
-    msgEl.textContent = 'لطفاً صبر کنید...';
-    try {
-      const res = await fetch('{% url "api_management_verify_face" %}', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-CSRFToken': getCsrf()
-        },
-        body: JSON.stringify({ image: dataUrl })
-      });
-      const j = await res.json();
-      if (j.success) {
-        msgEl.textContent = '✅ تأیید چهره موفق!';
-        setTimeout(() => { window.location.href = '{% url "management_dashboard" %}'; }, 1000);
-      } else {
-        msgEl.textContent = '❌ ' + (j.error || 'شناسایی ناموفق');
-        btn.disabled = false;
-      }
-    } catch (e) {
-      msgEl.textContent = '❌ خطا در ارتباط با سرور';
-      btn.disabled = false;
-    }
-  };
+    return canvas.toDataURL('image/png');
+  }
 
   function getCsrf() {
     return document.cookie.split(';')

--- a/templates/core/verify_face.html
+++ b/templates/core/verify_face.html
@@ -11,38 +11,55 @@ document.addEventListener('DOMContentLoaded', () => {
 
   if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
     navigator.mediaDevices.getUserMedia({ video: { facingMode: "user" } })
-      .then(stream => { video.srcObject = stream; })
+      .then(stream => { video.srcObject = stream; startSequence(); })
       .catch(() => { resultDiv.textContent = "دسترسی به دوربین ممکن نشد."; });
   } else {
     resultDiv.textContent = "دوربین توسط مرورگر پشتیبانی نمی‌شود.";
   }
 
-  setInterval(() => {
-    if (video.readyState === video.HAVE_ENOUGH_DATA) {
-      canvas.width = video.videoWidth;
-      canvas.height = video.videoHeight;
-      ctx.save();
-      ctx.scale(-1, 1);
-      ctx.drawImage(video, -canvas.width, 0, canvas.width, canvas.height);
-      ctx.restore();
-      const dataUrl = canvas.toDataURL('image/jpeg');
-      fetch("{% url 'api_verify_face' %}", {
-        method: "POST",
-        headers: { "Content-Type": "application/json", "X-CSRFToken": getCsrfToken() },
-        body: JSON.stringify({ image: dataUrl })
-      })
-      .then(r => r.json())
-      .then(data => {
-        if (data.ok) {
-          resultDiv.textContent = "چهره شما تأیید شد.";
-        } else {
-          resultDiv.textContent = data.msg || "چهره مطابقت نداشت.";
-        }
-      }).catch(() => {
-        resultDiv.textContent = "ارتباط با سرور برقرار نشد.";
-      });
+  function startSequence() {
+    if (video.readyState !== video.HAVE_ENOUGH_DATA) {
+      setTimeout(startSequence, 500);
+      return;
     }
-  }, 4000);
+    const captures = [];
+    resultDiv.textContent = "لطفاً مستقیم نگاه کنید.";
+    setTimeout(() => {
+      captures.push(capture());
+      resultDiv.textContent = "حالا سرتان را کمی به چپ یا راست بچرخانید.";
+      setTimeout(() => {
+        captures.push(capture());
+        resultDiv.textContent = "لطفاً صبر کنید...";
+        fetch("{% url 'api_verify_face' %}", {
+          method: "POST",
+          headers: { "Content-Type": "application/json", "X-CSRFToken": getCsrfToken() },
+          body: JSON.stringify({ image1: captures[0], image2: captures[1] })
+        })
+        .then(r => r.json())
+        .then(data => {
+          if (data.ok) {
+            resultDiv.textContent = "چهره شما تأیید شد.";
+          } else {
+            resultDiv.textContent = data.msg || "چهره مطابقت نداشت.";
+          }
+        }).catch(() => {
+          resultDiv.textContent = "ارتباط با سرور برقرار نشد.";
+        }).finally(() => {
+          setTimeout(startSequence, 4000);
+        });
+      }, 3000);
+    }, 1000);
+  }
+
+  function capture() {
+    canvas.width = video.videoWidth;
+    canvas.height = video.videoHeight;
+    ctx.save();
+    ctx.scale(-1, 1);
+    ctx.drawImage(video, -canvas.width, 0, canvas.width, canvas.height);
+    ctx.restore();
+    return canvas.toDataURL('image/jpeg');
+  }
 
   function getCsrfToken() {
     let value = "; " + document.cookie;


### PR DESCRIPTION
## Summary
- add timed automatic capture for manager face checks, taking the first frame after 1s and the second 3s after the movement prompt
- apply the same delayed two-frame liveness workflow to employee attendance without a button
- streamline face-check scripts to consistently send paired images for verification

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689f471d91e48333be0d31c8f007a0df