### PR TITLE
Unify face verification and liveness logic

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -53,7 +53,8 @@ from core.forms import (
 )
 from .models import Device
 
-
+FACE_DISTANCE_THRESHOLD = 0.5
+LIVENESS_MOVEMENT_THRESHOLD = 0.08
 
 User = get_user_model()
 
@@ -310,16 +311,25 @@ def api_device_verify_face(request):
 
     try:
         data = json.loads(request.body)
-        enc = _get_face_encoding_from_base64(data.get("image", ""))
-        if enc is None:
+        img1 = data.get("image1")
+        img2 = data.get("image2")
+        if not img1 or not img2:
+            return JsonResponse({"success": False, "error": "ارسال ناقص تصاویر."})
+        enc1 = _get_face_encoding_from_base64(img1)
+        enc2 = _get_face_encoding_from_base64(img2)
+        if enc1 is None or enc2 is None:
             return JsonResponse({"success": False, "error": "چهره یافت نشد."})
+        movement = np.linalg.norm(enc1 - enc2)
+        if movement < LIVENESS_MOVEMENT_THRESHOLD:
+            return JsonResponse({"success": False, "error": "حرکت تشخیص داده نشد."})
+        enc = (enc1 + enc2) / 2
 
         if request.user.face_encoding is None:
             return JsonResponse({"success": False, "error": "چهره مدیر ثبت نشده."})
 
         known = np.frombuffer(request.user.face_encoding, dtype=np.float64)
         distance = np.linalg.norm(known - enc)
-        if distance < 0.5:
+        if distance < FACE_DISTANCE_THRESHOLD:
             return JsonResponse({"success": True, "redirect": reverse("device_page")})
         else:
             return JsonResponse({"success": False, "error": "تشخیص ناموفق."})
@@ -340,19 +350,16 @@ def api_verify_face(request):
         data = json.loads(request.body)
         img1 = data.get("image1")
         img2 = data.get("image2")
-        if img1 and img2:
-            enc1 = _get_face_encoding_from_base64(img1)
-            enc2 = _get_face_encoding_from_base64(img2)
-            if enc1 is None or enc2 is None:
-                return JsonResponse({"ok": False, "msg": "چهره به‌وضوح دیده نشد. لطفاً روبه‌رو و در نور کافی قرار بگیرید."})
-            movement = np.linalg.norm(enc1 - enc2)
-            if movement < 0.08:
-                return JsonResponse({"ok": False, "msg": "حرکت تشخیص داده نشد. لطفاً دستور روی صفحه را اجرا کنید."})
-            enc = (enc1 + enc2) / 2
-        else:
-            enc = _get_face_encoding_from_base64(data.get("image", ""))
-            if enc is None:
-                return JsonResponse({"ok": False, "msg": "چهره به‌وضوح دیده نشد. لطفاً روبه‌رو و در نور کافی قرار بگیرید."})
+        if not img1 or not img2:
+            return JsonResponse({"ok": False, "msg": "ارسال ناقص تصاویر."})
+        enc1 = _get_face_encoding_from_base64(img1)
+        enc2 = _get_face_encoding_from_base64(img2)
+        if enc1 is None or enc2 is None:
+            return JsonResponse({"ok": False, "msg": "چهره به‌وضوح دیده نشد. لطفاً روبه‌رو و در نور کافی قرار بگیرید."})
+        movement = np.linalg.norm(enc1 - enc2)
+        if movement < LIVENESS_MOVEMENT_THRESHOLD:
+            return JsonResponse({"ok": False, "msg": "حرکت تشخیص داده نشد. لطفاً دستور روی صفحه را اجرا کنید."})
+        enc = (enc1 + enc2) / 2
         best_user = None
         best_dist = float("inf")
 
@@ -362,7 +369,7 @@ def api_verify_face(request):
             if dist < best_dist:
                 best_dist = dist
                 best_user = u
-            if dist < 0.5:
+            if dist < FACE_DISTANCE_THRESHOLD:
                 if u.is_staff:
                     return JsonResponse({"ok": False, "manager_detected": True})
                 last_log = AttendanceLog.objects.filter(user=u).order_by('-timestamp').first()
@@ -391,7 +398,7 @@ def api_verify_face(request):
         if best_user and best_dist < 0.6:
                                                      
             try:
-                raw_img = img1 or data.get("image", "")
+                raw_img = img1
                 header, b64data = raw_img.split(",", 1)
                 fmt = header.split(";")[0].split("/")[1]
                 img_data = base64.b64decode(b64data)
@@ -422,7 +429,7 @@ def api_register_face(request):
             return JsonResponse({"ok": False, "msg": "چهره واضح نیست."})
                                                                                   
         movement = np.linalg.norm(enc1 - enc2)
-        if movement < 0.08:
+        if movement < LIVENESS_MOVEMENT_THRESHOLD:
             return JsonResponse({"ok": False, "msg": "حرکت تشخیص داده نشد."})
         enc = (enc1 + enc2) / 2
         data_url = img1
@@ -668,35 +675,30 @@ def management_face_check(request):
 @login_required
 @staff_required
 def api_management_verify_face(request):
-    import base64
-    import face_recognition
-
     if request.method == "POST":
         try:
             data = json.loads(request.body)
-            image_data = data.get("image")
-            if not image_data:
-                return JsonResponse({"success": False, "error": "عکس ارسال نشده."})
-                          
-            image_b64 = image_data.split(",")[1]
-            img_bytes = base64.b64decode(image_b64)
-            np_arr = np.frombuffer(img_bytes, np.uint8)
-            import cv2
-            img = cv2.imdecode(np_arr, cv2.IMREAD_COLOR)
-            encs = face_recognition.face_encodings(img)
-            if not encs:
+            img1 = data.get("image1")
+            img2 = data.get("image2")
+            if not img1 or not img2:
+                return JsonResponse({"success": False, "error": "ارسال ناقص تصاویر."})
+            enc1 = _get_face_encoding_from_base64(img1)
+            enc2 = _get_face_encoding_from_base64(img2)
+            if enc1 is None or enc2 is None:
                 return JsonResponse({"success": False, "error": "چهره‌ای شناسایی نشد."})
-            enc = encs[0]
+            movement = np.linalg.norm(enc1 - enc2)
+            if movement < LIVENESS_MOVEMENT_THRESHOLD:
+                return JsonResponse({"success": False, "error": "حرکت تشخیص داده نشد."})
+            enc = (enc1 + enc2) / 2
             known = np.frombuffer(request.user.face_encoding, dtype=np.float64)
             distance = np.linalg.norm(known - enc)
-            if distance < 0.5:
-                                              
+            if distance < FACE_DISTANCE_THRESHOLD:
                 request.session["face_verified"] = True
                 return JsonResponse({"success": True})
             else:
                 return JsonResponse({"success": False, "error": "چهره مطابقت نداشت."})
-        except Exception as e:
-            return JsonResponse({"success": False, "error": f"خطا: {e}"})
+        except Exception:
+            return JsonResponse({"success": False, "error": "خطا در پردازش تصویر."})
     return JsonResponse({"success": False, "error": "درخواست نامعتبر."})
 
 
@@ -915,7 +917,7 @@ def register_face_api(request, user_id):
         enc2 = _get_face_encoding_from_base64(img2)
         if enc1 is None or enc2 is None:
             return JsonResponse({"ok": False, "msg": "چهره واضح نیست."})
-        if np.linalg.norm(enc1 - enc2) < 0.08:
+        if np.linalg.norm(enc1 - enc2) < LIVENESS_MOVEMENT_THRESHOLD:
             return JsonResponse({"ok": False, "msg": "حرکت تشخیص داده نشد."})
         enc = (enc1 + enc2) / 2
         data_url = img1

--- a/static/core/device.js
+++ b/static/core/device.js
@@ -131,12 +131,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
   setInterval(updateFraming, 800);
 
-  const challenges = [
-    { key: 'smile', msg: 'لطفاً کمی لبخند بزنید.' },
-    { key: 'left', msg: 'سر خود را به آرامی به چپ بچرخانید.' },
-    { key: 'right', msg: 'سر خود را به آرامی به راست بچرخانید.' },
-  ];
-
   function wait(ms) {
     return new Promise((resolve) => setTimeout(resolve, ms));
   }
@@ -147,11 +141,13 @@ document.addEventListener('DOMContentLoaded', () => {
       return;
     }
     verifying = true;
+    showMessage('لطفاً مستقیم به دوربین نگاه کنید.');
+    await wait(1000);
     const img1 = capture();
-    const challenge = challenges[Math.floor(Math.random() * challenges.length)];
-    showMessage(challenge.msg);
-    await wait(1200);
+    showMessage('حالا سرتان را کمی حرکت دهید.');
+    await wait(3000);
     const img2 = capture();
+    showMessage('در حال بررسی...');
 
     fetch(VERIFY_FACE_URL, {
       method: 'POST',
@@ -159,7 +155,7 @@ document.addEventListener('DOMContentLoaded', () => {
         'Content-Type': 'application/json',
         'X-CSRFToken': getCsrfToken(),
       },
-      body: JSON.stringify({ image1: img1, image2: img2, challenge: challenge.key }),
+      body: JSON.stringify({ image1: img1, image2: img2 }),
     })
       .then((r) => r.json())
       .then((data) => {

--- a/templates/core/device_face_check.html
+++ b/templates/core/device_face_check.html
@@ -9,51 +9,60 @@ document.addEventListener('DOMContentLoaded', () => {
   const ctx = canvas.getContext('2d');
   const btn = document.getElementById('verifyBtn');
   const message = document.getElementById('verifyResult');
-
-  message.textContent = 'صورت خود را در مرکز کادر قرار دهید و دکمه تأیید را بزنید';
+  let capture1 = null;
 
   if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
     navigator.mediaDevices.getUserMedia({ video: { facingMode: "user" } })
-      .then(stream => { video.srcObject = stream; message.textContent = ''; })
+      .then(stream => { video.srcObject = stream; })
       .catch(() => { message.textContent = 'دسترسی به دوربین ممکن نشد.'; btn.disabled = true; });
   } else {
     message.textContent = 'دوربین توسط مرورگر پشتیبانی نمی‌شود.';
     btn.disabled = true;
   }
 
-  btn.onclick = () => {
-    if (video.readyState !== video.HAVE_ENOUGH_DATA) {
-      message.textContent = 'لطفاً صبر کنید تا تصویر دوربین آماده شود';
-      return;
-    }
+  btn.onclick = async () => {
+    if (video.readyState !== video.HAVE_ENOUGH_DATA) return;
     btn.disabled = true;
+    message.textContent = 'لطفاً مستقیم به دوربین نگاه کنید.';
+    await wait(1000);
+    capture1 = grabFrame();
+    message.textContent = 'حالا سرتان را کمی حرکت دهید.';
+    await wait(3000);
+    const capture2 = grabFrame();
+    message.textContent = 'در حال بررسی...';
+    try {
+      const res = await fetch("{% url 'api_device_verify_face' %}", {
+        method: 'POST',
+        headers: { "Content-Type": "application/json", "X-CSRFToken": getCsrfToken() },
+        body: JSON.stringify({ image1: capture1, image2: capture2 })
+      });
+      const data = await res.json();
+      if (data.success) {
+        message.textContent = 'چهره تأیید شد. کیوسک فعال شد.';
+        setTimeout(() => { window.location.href = data.redirect; }, 1000);
+      } else {
+        message.textContent = data.error || 'چهره مطابقت نداشت.';
+        btn.disabled = false;
+      }
+    } catch (e) {
+      message.textContent = 'ارتباط با سرور برقرار نشد.';
+      btn.disabled = false;
+    }
+  };
+
+  function grabFrame() {
     canvas.width = video.videoWidth;
     canvas.height = video.videoHeight;
     ctx.save();
     ctx.scale(-1, 1);
     ctx.drawImage(video, -canvas.width, 0, canvas.width, canvas.height);
     ctx.restore();
-    const dataUrl = canvas.toDataURL('image/jpeg');
-    message.textContent = 'لطفاً صبر کنید...';
-    fetch("{% url 'api_device_verify_face' %}", {
-      method: 'POST',
-      headers: { "Content-Type": "application/json", "X-CSRFToken": getCsrfToken() },
-      body: JSON.stringify({ image: dataUrl })
-    })
-    .then(r => r.json())
-    .then(data => {
-      if (data.success) {
-        message.textContent = "چهره تأیید شد. کیوسک فعال شد.";
-        setTimeout(() => { window.location.href = data.redirect; }, 1000);
-      } else {
-        message.textContent = data.error || "چهره مطابقت نداشت.";
-        btn.disabled = false;
-      }
-    }).catch(() => {
-      message.textContent = "ارتباط با سرور برقرار نشد.";
-      btn.disabled = false;
-    });
-  };
+    return canvas.toDataURL('image/jpeg');
+  }
+
+  function wait(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
 
   function getCsrfToken() {
     let value = "; " + document.cookie;

--- a/templates/core/management_face_check.html
+++ b/templates/core/management_face_check.html
@@ -9,12 +9,11 @@ document.addEventListener('DOMContentLoaded', () => {
   const ctx = canvas.getContext('2d');
   const btn = document.getElementById('verifyBtn');
   const msgEl = document.getElementById('verifyResult');
-
-  msgEl.textContent = 'صورت خود را در مرکز کادر قرار دهید و دکمه تأیید را بزنید';
+  let capture1 = null;
 
   if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
     navigator.mediaDevices.getUserMedia({ video: { facingMode: "user" } })
-      .then(stream => { video.srcObject = stream; msgEl.textContent = ''; })
+      .then(stream => { video.srcObject = stream; })
       .catch(() => { msgEl.textContent = 'اجازه دوربین رد شد'; btn.disabled = true; });
   } else {
     msgEl.textContent = 'دوربین توسط مرورگر پشتیبانی نمی‌شود.';
@@ -22,20 +21,15 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   btn.onclick = async () => {
-    if (video.readyState !== video.HAVE_ENOUGH_DATA) {
-      msgEl.textContent = 'لطفاً صبر کنید تا تصویر دوربین آماده شود';
-      return;
-    }
+    if (video.readyState !== video.HAVE_ENOUGH_DATA) return;
     btn.disabled = true;
-    canvas.width = video.videoWidth;
-    canvas.height = video.videoHeight;
-    ctx.save();
-    ctx.scale(-1, 1);
-    ctx.drawImage(video, -canvas.width, 0, canvas.width, canvas.height);
-    ctx.restore();
-    const dataUrl = canvas.toDataURL('image/png');
-
-    msgEl.textContent = 'لطفاً صبر کنید...';
+    msgEl.textContent = 'لطفاً مستقیم به دوربین نگاه کنید.';
+    await wait(1000);
+    capture1 = grabFrame();
+    msgEl.textContent = 'حالا سرتان را کمی حرکت دهید.';
+    await wait(3000);
+    const capture2 = grabFrame();
+    msgEl.textContent = 'در حال بررسی...';
     try {
       const res = await fetch('{% url "api_management_verify_face" %}', {
         method: 'POST',
@@ -43,7 +37,7 @@ document.addEventListener('DOMContentLoaded', () => {
           'Content-Type': 'application/json',
           'X-CSRFToken': getCsrf()
         },
-        body: JSON.stringify({ image: dataUrl })
+        body: JSON.stringify({ image1: capture1, image2: capture2 })
       });
       const j = await res.json();
       if (j.success) {
@@ -58,6 +52,20 @@ document.addEventListener('DOMContentLoaded', () => {
       btn.disabled = false;
     }
   };
+
+  function grabFrame() {
+    canvas.width = video.videoWidth;
+    canvas.height = video.videoHeight;
+    ctx.save();
+    ctx.scale(-1, 1);
+    ctx.drawImage(video, -canvas.width, 0, canvas.width, canvas.height);
+    ctx.restore();
+    return canvas.toDataURL('image/jpeg');
+  }
+
+  function wait(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
 
   function getCsrf() {
     return document.cookie.split(';')

--- a/templates/core/verify_face.html
+++ b/templates/core/verify_face.html
@@ -17,32 +17,49 @@ document.addEventListener('DOMContentLoaded', () => {
     resultDiv.textContent = "دوربین توسط مرورگر پشتیبانی نمی‌شود.";
   }
 
-  setInterval(() => {
-    if (video.readyState === video.HAVE_ENOUGH_DATA) {
-      canvas.width = video.videoWidth;
-      canvas.height = video.videoHeight;
-      ctx.save();
-      ctx.scale(-1, 1);
-      ctx.drawImage(video, -canvas.width, 0, canvas.width, canvas.height);
-      ctx.restore();
-      const dataUrl = canvas.toDataURL('image/jpeg');
-      fetch("{% url 'api_verify_face' %}", {
-        method: "POST",
-        headers: { "Content-Type": "application/json", "X-CSRFToken": getCsrfToken() },
-        body: JSON.stringify({ image: dataUrl })
-      })
-      .then(r => r.json())
-      .then(data => {
-        if (data.ok) {
-          resultDiv.textContent = "چهره شما تأیید شد.";
-        } else {
-          resultDiv.textContent = data.msg || "چهره مطابقت نداشت.";
-        }
-      }).catch(() => {
-        resultDiv.textContent = "ارتباط با سرور برقرار نشد.";
-      });
+  async function verifyLoop() {
+    if (video.readyState !== video.HAVE_ENOUGH_DATA) {
+      setTimeout(verifyLoop, 1000);
+      return;
     }
-  }, 4000);
+    resultDiv.textContent = 'لطفاً مستقیم به دوربین نگاه کنید.';
+    await wait(1000);
+    const img1 = grabFrame();
+    resultDiv.textContent = 'حالا سرتان را کمی حرکت دهید.';
+    await wait(3000);
+    const img2 = grabFrame();
+    resultDiv.textContent = 'در حال بررسی...';
+    try {
+      const r = await fetch("{% url 'api_verify_face' %}", {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-CSRFToken': getCsrfToken() },
+        body: JSON.stringify({ image1: img1, image2: img2 })
+      });
+      const data = await r.json();
+      if (data.ok) {
+        resultDiv.textContent = 'چهره شما تأیید شد.';
+      } else {
+        resultDiv.textContent = data.msg || 'چهره مطابقت نداشت.';
+      }
+    } catch (e) {
+      resultDiv.textContent = 'ارتباط با سرور برقرار نشد.';
+    }
+    setTimeout(verifyLoop, 4000);
+  }
+
+  function grabFrame() {
+    canvas.width = video.videoWidth;
+    canvas.height = video.videoHeight;
+    ctx.save();
+    ctx.scale(-1, 1);
+    ctx.drawImage(video, -canvas.width, 0, canvas.width, canvas.height);
+    ctx.restore();
+    return canvas.toDataURL('image/jpeg');
+  }
+
+  function wait(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
 
   function getCsrfToken() {
     let value = "; " + document.cookie;
@@ -50,6 +67,8 @@ document.addEventListener('DOMContentLoaded', () => {
     if (parts.length === 2) return parts.pop().split(";").shift();
     return '';
   }
+
+  verifyLoop();
 });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- automate manager face checks with delayed dual snapshots
- run employee attendance with the same timed head-movement sequence
- require two images for all face verification APIs

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689f471d91e48333be0d31c8f007a0df