### PR TITLE
Disable face verification button during auth

### DIFF
--- a/static/core/global.css
+++ b/static/core/global.css
@@ -634,6 +634,14 @@ label {
   box-shadow: 0 0.4rem 0.8rem rgba(0,0,0,0.3);
 }
 
+.action-btn:disabled {
+  background: var(--color-muted);
+  cursor: not-allowed;
+  transform: translateX(-50%);
+  box-shadow: none;
+  opacity: 0.6;
+}
+
 
 .tabs {
   list-style: none;

--- a/templates/core/device_face_check.html
+++ b/templates/core/device_face_check.html
@@ -10,6 +10,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const btn = document.getElementById('verifyBtn');
   const message = document.getElementById('verifyResult');
   let capture1 = null;
+  let verifying = false;
 
   if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
     navigator.mediaDevices.getUserMedia({ video: { facingMode: "user" } })
@@ -21,7 +22,8 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   btn.onclick = async () => {
-    if (video.readyState !== video.HAVE_ENOUGH_DATA) return;
+    if (verifying || video.readyState !== video.HAVE_ENOUGH_DATA) return;
+    verifying = true;
     btn.disabled = true;
     message.textContent = 'لطفاً مستقیم به دوربین نگاه کنید.';
     await wait(1000);
@@ -43,10 +45,12 @@ document.addEventListener('DOMContentLoaded', () => {
       } else {
         message.textContent = data.error || 'چهره مطابقت نداشت.';
         btn.disabled = false;
+        verifying = false;
       }
     } catch (e) {
       message.textContent = 'ارتباط با سرور برقرار نشد.';
       btn.disabled = false;
+      verifying = false;
     }
   };
 

--- a/templates/core/management_face_check.html
+++ b/templates/core/management_face_check.html
@@ -10,6 +10,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const btn = document.getElementById('verifyBtn');
   const msgEl = document.getElementById('verifyResult');
   let capture1 = null;
+  let verifying = false;
 
   if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
     navigator.mediaDevices.getUserMedia({ video: { facingMode: "user" } })
@@ -21,7 +22,8 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   btn.onclick = async () => {
-    if (video.readyState !== video.HAVE_ENOUGH_DATA) return;
+    if (verifying || video.readyState !== video.HAVE_ENOUGH_DATA) return;
+    verifying = true;
     btn.disabled = true;
     msgEl.textContent = 'لطفاً مستقیم به دوربین نگاه کنید.';
     await wait(1000);
@@ -46,10 +48,12 @@ document.addEventListener('DOMContentLoaded', () => {
       } else {
         msgEl.textContent = '❌ ' + (j.error || 'شناسایی ناموفق');
         btn.disabled = false;
+        verifying = false;
       }
     } catch (e) {
       msgEl.textContent = '❌ خطا در ارتباط با سرور';
       btn.disabled = false;
+      verifying = false;
     }
   };
 


### PR DESCRIPTION
## Summary
- Prevent multiple submissions by tracking verification state and disabling the manager face check button
- Apply the same safeguard to device face verification
- Style disabled action buttons for clear visual feedback

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a02359994c8333a88b75209da6f6b8