### PR TITLE
Simplify helpers and streamline date conversion

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -145,15 +145,21 @@ class LeaveRequestForm(forms.ModelForm):
         sd = cleaned_data.get("start_date")
         dur = cleaned_data.get("duration")
         if sd:
-            cleaned_data["start_date"] = sd.togregorian()
+            start_g = sd.togregorian()
+            cleaned_data["start_date"] = start_g
         if sd and dur:
             end_j = sd + jdatetime.timedelta(days=dur - 1)
-            cleaned_data["end_date"] = end_j.togregorian()
+            end_g = end_j.togregorian()
+            cleaned_data["end_date"] = end_g
             cleaned_data["end_jalali"] = end_j
         user = self.user or cleaned_data.get("user")
         if user and sd and dur:
-            if LeaveRequest.objects.filter(user=user, start_date=sd.togregorian(), end_date=end_j.togregorian()).exists():
-                raise forms.ValidationError("برای این بازه قبلاً درخواستی ثبت شده است.")
+            if LeaveRequest.objects.filter(
+                user=user, start_date=start_g, end_date=end_g
+            ).exists():
+                raise forms.ValidationError(
+                    "برای این بازه قبلاً درخواستی ثبت شده است."
+                )
         return cleaned_data
 
     def save(self, commit=True):
@@ -235,13 +241,19 @@ class ManualLeaveForm(forms.ModelForm):
         if sd and ed and ed < sd:
             self.add_error("end_date", "بازه نامعتبر است")
         if sd:
-            cleaned_data["start_date"] = sd.togregorian()
+            start_g = sd.togregorian()
+            cleaned_data["start_date"] = start_g
         if ed:
-            cleaned_data["end_date"] = ed.togregorian()
+            end_g = ed.togregorian()
+            cleaned_data["end_date"] = end_g
         user = cleaned_data.get("user")
         if user and sd and ed:
-            if LeaveRequest.objects.filter(user=user, start_date=sd.togregorian(), end_date=ed.togregorian()).exists():
-                raise forms.ValidationError("برای این بازه قبلاً درخواستی ثبت شده است.")
+            if LeaveRequest.objects.filter(
+                user=user, start_date=start_g, end_date=end_g
+            ).exists():
+                raise forms.ValidationError(
+                    "برای این بازه قبلاً درخواستی ثبت شده است."
+                )
         return cleaned_data
 
     def save(self, commit=True):

--- a/core/views.py
+++ b/core/views.py
@@ -60,21 +60,22 @@ MATCH_SAVE_DISTANCE = 0.6
 User = get_user_model()
 
 
-def _now():
-    return timezone.now().replace(tzinfo=None)
-
-
 def _to_naive(dt):
-    return dt.replace(tzinfo=None) if dt and dt.tzinfo is not None else dt
+    return dt.replace(tzinfo=None) if dt and dt.tzinfo else dt
+
+
+def _now():
+    return _to_naive(timezone.now())
 
 
 def _get_user_shift(user):
+    shift = getattr(user, "shift", None)
+    if shift:
+        return shift
+    group = getattr(user, "group", None)
+    return getattr(group, "shift", None)
 
-    if getattr(user, "shift", None):
-        return user.shift
-    if getattr(user, "group", None) and user.group and user.group.shift:
-        return user.group.shift
-    return None
+
 def _weekday_index(date):
 
     return (date.weekday() + 2) % 7


### PR DESCRIPTION
## Summary
- refactor timezone helpers for clarity
- avoid duplicate to-gregorian conversions in leave request forms

## Testing
- `python manage.py check`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a02f3f422c8333b85ec8ab5810ceb9