### PR TITLE
Rename request labels and show monthly performance

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -53,7 +53,7 @@ class CustomUserSimpleForm(forms.ModelForm):
             "is_staff",
         ]
 
-# فرم درخواست ویرایش تردد
+# فرم درخواست اصلاح تردد
 class EditRequestForm(forms.ModelForm):
     date = jforms.jDateField(label="تاریخ", widget=JalaliDateInput())
     log_type = forms.ChoiceField(choices=LOG_TYPE_CHOICES, label="نوع تردد")

--- a/core/forms.py
+++ b/core/forms.py
@@ -392,12 +392,3 @@ class MonthlyPerformanceForm(forms.Form):
         (12, "اسفند"),
     ]
     month = forms.ChoiceField(label="ماه", choices=MONTH_CHOICES, initial=jdatetime.date.today().month)
-
-# فرم عملکرد ماهانه برای کاربر
-class UserMonthlyPerformanceForm(forms.Form):
-    year = forms.IntegerField(label="سال", initial=jdatetime.date.today().year)
-    month = forms.ChoiceField(
-        label="ماه",
-        choices=MonthlyPerformanceForm.MONTH_CHOICES,
-        initial=jdatetime.date.today().month,
-    )

--- a/core/forms.py
+++ b/core/forms.py
@@ -392,3 +392,12 @@ class MonthlyPerformanceForm(forms.Form):
         (12, "اسفند"),
     ]
     month = forms.ChoiceField(label="ماه", choices=MONTH_CHOICES, initial=jdatetime.date.today().month)
+
+# فرم عملکرد ماهانه برای کاربر
+class UserMonthlyPerformanceForm(forms.Form):
+    year = forms.IntegerField(label="سال", initial=jdatetime.date.today().year)
+    month = forms.ChoiceField(
+        label="ماه",
+        choices=MonthlyPerformanceForm.MONTH_CHOICES,
+        initial=jdatetime.date.today().month,
+    )

--- a/static/core/global.css
+++ b/static/core/global.css
@@ -682,3 +682,43 @@ label {
 @media (max-width: 900px) {
   .request-cards { display: flex; flex-direction: column; gap: 1rem; }
 }
+
+/* Monthly performance dashboard */
+.dashboard-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1rem;
+  margin-bottom: 2.4rem;
+}
+
+@media (min-width: 1000px) {
+  .dashboard-stats {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.dashboard-card {
+  background: var(--color-bg);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  border: 1px solid var(--color-border);
+  padding: 1rem 0.8rem;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.dashboard-card .value {
+  font-size: 1.4rem;
+  font-weight: 700;
+  margin-bottom: 0.3rem;
+  color: var(--color-primary-dark);
+}
+
+.dashboard-card .label {
+  font-size: 0.9rem;
+  color: var(--color-muted);
+}
+

--- a/static/core/management.css
+++ b/static/core/management.css
@@ -141,45 +141,10 @@
   align-items: flex-start;
   margin-bottom: 2rem;
 }
-.dashboard-stats {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  gap: 1rem;
-  margin-bottom: 2.4rem;
-}
-@media (min-width: 1000px) {
-  .dashboard-stats {
-    grid-template-columns: repeat(2, 1fr);
-  }
-}
-.dashboard-card {
-  background: var(--color-bg);
-  border-radius: var(--radius);
-  box-shadow: var(--shadow);
-  padding: 1rem 0.8rem;
-  text-align: center;
-  border: 1px solid var(--color-border);
-  font-size: 1rem;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  min-height: 100px;
-}
 .dashboard-card i {
   color: var(--color-primary-dark);
   font-size: 1.3rem;
   margin-bottom: 0.4rem;
-}
-.dashboard-card .value {
-  font-size: 1.4rem;
-  font-weight: 700;
-  margin-bottom: 0.3rem;
-  color: var(--color-primary-dark);
-}
-.dashboard-card .label {
-  font-size: 0.9rem;
-  color: var(--color-muted);
 }
 .management-table {
   width: 100%;

--- a/templates/core/admin_user_profile.html
+++ b/templates/core/admin_user_profile.html
@@ -48,7 +48,7 @@
     {{ requests_form.end.label }} {{ requests_form.end }}
     <button class="btn" type="submit">نمایش</button>
   </form>
-  <h3>درخواست‌های ویرایش</h3>
+  <h3>اصلاح تردد</h3>
   <div class="table-responsive">
     <table class="management-table">
       <thead><tr><th>زمان</th><th>نوع</th><th>وضعیت</th></tr></thead>
@@ -65,7 +65,7 @@
       </tbody>
     </table>
   </div>
-  <h3 style="margin-top:1rem;">درخواست‌های مرخصی</h3>
+  <h3 style="margin-top:1rem;">مرخصی‌ها</h3>
   <div class="table-responsive">
     <table class="management-table">
       <thead><tr><th>بازه</th><th>نوع</th><th>وضعیت</th></tr></thead>

--- a/templates/core/base_management.html
+++ b/templates/core/base_management.html
@@ -29,7 +29,7 @@
           <i class="fas fa-exclamation-triangle"></i> موارد مشکوک
         </a>
         <a href="{% url 'edit_requests' %}" class="{% if request.resolver_match.url_name == 'edit_requests' %}active{% endif %}">
-          <i class="fas fa-edit"></i> درخواست‌های ویرایش
+          <i class="fas fa-edit"></i> اصلاح تردد
         </a>
       <a href="{% url 'leave_requests' %}" class="{% if request.resolver_match.url_name == 'leave_requests' %}active{% endif %}">
         <i class="fas fa-calendar-check"></i> مرخصی‌ها

--- a/templates/core/edit_request_form.html
+++ b/templates/core/edit_request_form.html
@@ -1,8 +1,8 @@
 {% extends "core/base.html" %}
-{% block title %}درخواست ویرایش تردد{% endblock %}
+{% block title %}درخواست اصلاح تردد{% endblock %}
 {% block content %}
 <div class="card page page-md">
-  <h2 class="page-title">درخواست ویرایش تردد برای {{ user.get_full_name }}</h2>
+  <h2 class="page-title">درخواست اصلاح تردد برای {{ user.get_full_name }}</h2>
   <form method="post">
     {% csrf_token %}
     {{ form.non_field_errors }}

--- a/templates/core/edit_requests.html
+++ b/templates/core/edit_requests.html
@@ -1,10 +1,10 @@
 {% extends "core/base_management.html" %}
 {% load jformat %}
-{% block title %}درخواست‌های ویرایش{% endblock %}
+{% block title %}اصلاح تردد{% endblock %}
 {% block management_content %}
 <h2 class="page-title">
   <i class="fas fa-edit"></i>
-  درخواست‌های ویرایش
+  اصلاح تردد
 </h2>
 <form method="get" class="form-inline" style="margin-bottom:1rem;">
   <select name="group">

--- a/templates/core/leave_requests.html
+++ b/templates/core/leave_requests.html
@@ -1,10 +1,10 @@
 {% extends "core/base_management.html" %}
 {% load jformat %}
-{% block title %}درخواست‌های مرخصی{% endblock %}
+{% block title %}مرخصی‌ها{% endblock %}
 {% block management_content %}
 <h2 class="page-title">
   <i class="fas fa-calendar-check"></i>
-  درخواست‌های مرخصی
+  مرخصی‌ها
 </h2>
 <form method="get" class="form-inline" style="margin-bottom:1rem;">
   <select name="group">

--- a/templates/core/management_dashboard.html
+++ b/templates/core/management_dashboard.html
@@ -72,10 +72,10 @@
       <li>{{ u.get_full_name }} - {{ u.personnel_code }} دیرکرد در ورود</li>
     {% endfor %}
     {% if pending_edits %}
-      <li>{{ pending_edits }} درخواست ویرایش تردد در انتظار</li>
+      <li>{{ pending_edits }} اصلاح تردد در انتظار</li>
     {% endif %}
     {% if pending_leaves %}
-      <li>{{ pending_leaves }} درخواست مرخصی در انتظار</li>
+      <li>{{ pending_leaves }} مرخصی در انتظار</li>
     {% endif %}
     {% if suspicious_today %}
       <li>{{ suspicious_today }} مورد عدم تطابق چهره</li>

--- a/templates/core/user_profile.html
+++ b/templates/core/user_profile.html
@@ -28,8 +28,9 @@
 
   <ul class="tabs">
     <li><a href="#logs" class="tab-link active">مشاهده تردد</a></li>
-    <li><a href="#edit-requests" class="tab-link">درخواست‌های ویرایش</a></li>
-    <li><a href="#leave-requests" class="tab-link">درخواست‌های مرخصی</a></li>
+    <li><a href="#edit-requests" class="tab-link">اصلاح تردد</a></li>
+    <li><a href="#leave-requests" class="tab-link">مرخصی‌ها</a></li>
+    <li><a href="#monthly-performance" class="tab-link">عملکرد ماهانه</a></li>
   </ul>
 
   <div id="logs" class="tab-content active">
@@ -197,6 +198,23 @@
     {% endif %}
     <div class="profile-actions">
       <a class="btn" href="{% url 'leave_request' %}" style="margin-left:0.5rem;"><i class="fa fa-calendar-plus" style="margin-left:0.4rem;"></i> درخواست جدید</a>
+    </div>
+  </div>
+
+  <div id="monthly-performance" class="tab-content">
+    <div class="table-responsive">
+      <table class="management-table">
+        <tbody>
+          <tr><td>دقایق حضور</td><td>{{ monthly_report.present_minutes }}</td></tr>
+          <tr><td>دقایق موظفی</td><td>{{ monthly_report.mandatory_minutes }}</td></tr>
+          <tr><td>ساعت حضور</td><td>{{ monthly_report.present_hours }}</td></tr>
+          <tr><td>ساعت موظفی</td><td>{{ monthly_report.required_hours }}</td></tr>
+          <tr><td>دقایق تأخیر</td><td>{{ monthly_report.tardy_minutes }}</td></tr>
+          <tr><td>دقایق اضافه‌کاری</td><td>{{ monthly_report.overtime_minutes }}</td></tr>
+          <tr><td>روزهای غیبت</td><td>{{ monthly_report.absence_days }}</td></tr>
+          <tr><td>روزهای ناقص</td><td>{% if monthly_report.incomplete_days %}{% for d in monthly_report.incomplete_days %}{{ d|jformat:"%Y/%m/%d" }}{% if not forloop.last %}، {% endif %}{% endfor %}{% else %}-{% endif %}</td></tr>
+        </tbody>
+      </table>
     </div>
   </div>
 

--- a/templates/core/user_profile.html
+++ b/templates/core/user_profile.html
@@ -202,20 +202,30 @@
   </div>
 
   <div id="monthly-performance" class="tab-content">
-    <div class="table-responsive">
-      <table class="management-table">
-        <tbody>
-          <tr><td>دقایق حضور</td><td>{{ monthly_report.present_minutes }}</td></tr>
-          <tr><td>دقایق موظفی</td><td>{{ monthly_report.mandatory_minutes }}</td></tr>
-          <tr><td>ساعت حضور</td><td>{{ monthly_report.present_hours }}</td></tr>
-          <tr><td>ساعت موظفی</td><td>{{ monthly_report.required_hours }}</td></tr>
-          <tr><td>دقایق تأخیر</td><td>{{ monthly_report.tardy_minutes }}</td></tr>
-          <tr><td>دقایق اضافه‌کاری</td><td>{{ monthly_report.overtime_minutes }}</td></tr>
-          <tr><td>روزهای غیبت</td><td>{{ monthly_report.absence_days }}</td></tr>
-          <tr><td>روزهای ناقص</td><td>{% if monthly_report.incomplete_days %}{% for d in monthly_report.incomplete_days %}{{ d|jformat:"%Y/%m/%d" }}{% if not forloop.last %}، {% endif %}{% endfor %}{% else %}-{% endif %}</td></tr>
-        </tbody>
-      </table>
+    <form method="get" action="#monthly-performance" class="card report-filter" style="margin-top:1rem;">
+      <div class="form-grid">
+        <div>{{ mp_form.year.label_tag }}{{ mp_form.year }}</div>
+        <div>{{ mp_form.month.label_tag }}{{ mp_form.month }}</div>
+      </div>
+      <button type="submit" class="btn">نمایش</button>
+    </form>
+    <div class="dashboard-stats" style="margin-top:1rem;">
+      <div class="dashboard-card"><div class="value">{{ monthly_report.required_hours }}</div><div class="label">ساعات موظفی</div></div>
+      <div class="dashboard-card"><div class="value">{{ monthly_report.present_hours }}</div><div class="label">ساعات حضور</div></div>
+      <div class="dashboard-card"><div class="value">{{ monthly_report.overtime_minutes }}</div><div class="label">اضافه/کسری (دقیقه)</div></div>
+      <div class="dashboard-card"><div class="value">{{ monthly_report.absence_days }}</div><div class="label">روز غیبت</div></div>
+      <div class="dashboard-card"><div class="value">{{ monthly_report.tardy_minutes }}</div><div class="label">دقایق تأخیر</div></div>
     </div>
+    {% if monthly_report.incomplete_days %}
+    <div class="card" style="margin-top:1rem;">
+      <h4>تردد ناقص</h4>
+      <ul>
+        {% for d in monthly_report.incomplete_days %}
+          <li>{{ d|jformat:"%Y/%m/%d" }}</li>
+        {% endfor %}
+      </ul>
+    </div>
+    {% endif %}
   </div>
 
   <div class="profile-actions" style="margin-top:1rem;">


### PR DESCRIPTION
## Summary
- Replace all "edit request" references with "اصلاح تردد" and rename "leave requests" to "مرخصی‌ها"
- Add a new "عملکرد ماهانه" tab on user profile showing monthly performance metrics

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a3af0461d08333a6ca78dc0ab1f7dc