### PR TITLE
Cancel new user if face registration is abandoned

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -41,6 +41,7 @@ urlpatterns = [
 
     path("management/users/",                views.management_users,               name="management_users"),
     path("management/users/add/",            views.user_add,                       name="user_add"),
+    path("management/users/<int:pk>/add/cancel/", views.user_add_cancel, name="user_add_cancel"),
     path("management/users/<int:pk>/edit/",  views.user_update,                    name="user_update"),
     path("management/users/<int:pk>/delete/",views.user_delete,                    name="user_delete"),
     path("management/users/<int:pk>/profile/", views.admin_user_profile, name="admin_user_profile"),

--- a/templates/core/register_face_for_user.html
+++ b/templates/core/register_face_for_user.html
@@ -24,6 +24,18 @@
 {% block extra_js %}
 <script>
 document.addEventListener('DOMContentLoaded', () => { // ثبت چهره برای کارمند
+  const isNew = {{ is_new|yesno:'true,false' }};
+  if (isNew) {
+    history.pushState(null, document.title, location.href);
+    window.addEventListener('popstate', () => {
+      fetch("{% url 'user_add_cancel' user_to_register.pk %}", {
+        method: 'POST',
+        headers: { 'X-CSRFToken': getCsrfToken() },
+        keepalive: true
+      });
+      window.location.href = "{% url 'management_users' %}";
+    });
+  }
   const video = document.getElementById('video');
   const canvas = document.getElementById('canvas');
   const ctx = canvas.getContext('2d');


### PR DESCRIPTION
## Summary
- Track newly created employee in session and expose cancel endpoint
- Clear pending user after face registration and intercept back navigation to delete user

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a63cf08b3083339d64ac6d1204a209